### PR TITLE
Update ICoinExClient.cs

### DIFF
--- a/CoinEx.Net/Interfaces/ICoinExClient.cs
+++ b/CoinEx.Net/Interfaces/ICoinExClient.cs
@@ -184,7 +184,7 @@ namespace CoinEx.Net.Interfaces
         /// <param name="limit">The number of results to return per page</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<IEnumerable<CoinExDeposit>>> GetDepositHistoryHistoryAsync(string? coin = null, int? page = null, int? limit = null, CancellationToken ct = default);
+        Task<WebCallResult<IEnumerable<CoinExDeposit>>> GetDepositHistoryAsync(string? coin = null, int? page = null, int? limit = null, CancellationToken ct = default);
 
 
         /// <summary>


### PR DESCRIPTION
The word "History" was redundant in the name of method.