### PR TITLE
Query the initial book instead of waiting for the snapshot to set the…

### DIFF
--- a/CoinEx.Net.UnitTests/OrderBookTests.cs
+++ b/CoinEx.Net.UnitTests/OrderBookTests.cs
@@ -1,0 +1,24 @@
+﻿using CoinEx.Net.SymbolOrderBooks;
+using CryptoExchange.Net.Objects;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace CoinEx.Net.UnitTests
+{
+    [TestFixture]
+    public class OrderBookTests
+    {
+        [TestCase]
+        public async Task StartOrderBook_Should_BeSynced()
+        {
+            // arrange
+            using var book = new CoinExSpotSymbolOrderBook("BTCUSDT");
+
+            // act
+            await book.StartAsync();
+
+            // assert
+            Assert.That(book.Status == OrderBookStatus.Synced);
+        }
+    }
+}

--- a/CoinEx.Net/Clients/SpotApi/CoinExSocketClientSpotApi.cs
+++ b/CoinEx.Net/Clients/SpotApi/CoinExSocketClientSpotApi.cs
@@ -181,13 +181,13 @@ namespace CoinEx.Net.Clients.SpotApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int limit, int mergeDepth, Action<DataEvent<CoinExSocketOrderBook>> onMessage, CancellationToken ct = default)
+        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int limit, int mergeDepth, Action<DataEvent<CoinExSocketOrderBook>> onMessage, bool diffUpdates, CancellationToken ct = default)
         {
             symbol.ValidateCoinExSymbol();
             mergeDepth.ValidateIntBetween(nameof(mergeDepth), 0, 8);
             limit.ValidateIntValues(nameof(limit), 5, 10, 20);
 
-            var subscription = new CoinExDepthSubscription(_logger, symbol, new object[] { symbol, limit, CoinExHelpers.MergeDepthIntToString(mergeDepth), true }, onMessage);
+            var subscription = new CoinExDepthSubscription(_logger, symbol, new object[] { symbol, limit, CoinExHelpers.MergeDepthIntToString(mergeDepth), diffUpdates }, onMessage);
             return await SubscribeAsync(subscription, ct).ConfigureAwait(false);
         }
 

--- a/CoinEx.Net/Clients/SpotApi/CoinExSocketClientSpotApi.cs
+++ b/CoinEx.Net/Clients/SpotApi/CoinExSocketClientSpotApi.cs
@@ -187,7 +187,7 @@ namespace CoinEx.Net.Clients.SpotApi
             mergeDepth.ValidateIntBetween(nameof(mergeDepth), 0, 8);
             limit.ValidateIntValues(nameof(limit), 5, 10, 20);
 
-            var subscription = new CoinExDepthSubscription(_logger, symbol, new object[] { symbol, limit, CoinExHelpers.MergeDepthIntToString(mergeDepth), false }, onMessage);
+            var subscription = new CoinExDepthSubscription(_logger, symbol, new object[] { symbol, limit, CoinExHelpers.MergeDepthIntToString(mergeDepth), true }, onMessage);
             return await SubscribeAsync(subscription, ct).ConfigureAwait(false);
         }
 

--- a/CoinEx.Net/Interfaces/Clients/SpotApi/ICoinExSocketClientSpotApi.cs
+++ b/CoinEx.Net/Interfaces/Clients/SpotApi/ICoinExSocketClientSpotApi.cs
@@ -76,9 +76,10 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApi
         /// <param name="limit">The limit of results to receive in a update</param>
         /// <param name="mergeDepth">The depth of merging, based on 8 decimals. 1 mergeDepth will merge the last decimals of all order in the book, 7 will merge the last 7 decimals of all orders together</param>
         /// <param name="onMessage">Data handler</param>
+        /// <param name="diffUpdates">Set to true to get snapshot first, then diff updates</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int limit, int mergeDepth, Action<DataEvent<CoinExSocketOrderBook>> onMessage, CancellationToken ct = default);
+        Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int limit, int mergeDepth, Action<DataEvent<CoinExSocketOrderBook>> onMessage, bool diffUpdates = false, CancellationToken ct = default);
 
         /// <summary>
         /// Gets the latest trades on a symbol

--- a/CoinEx.Net/SymbolOrderBooks/CoinExSpotSymbolOrderBook.cs
+++ b/CoinEx.Net/SymbolOrderBooks/CoinExSpotSymbolOrderBook.cs
@@ -76,6 +76,10 @@ namespace CoinEx.Net.SymbolOrderBooks
 
             Status = OrderBookStatus.Syncing;
 
+            // Query the initial order book
+            var initialBook = await _socketClient.SpotApi.GetOrderBookAsync(Symbol, Levels!.Value, 0).ConfigureAwait(false);
+            SetInitialOrderBook(DateTime.UtcNow.Ticks, initialBook.Data.Bids, initialBook.Data.Asks);
+
             var setResult = await WaitForSetOrderBookAsync(_initialDataTimeout, ct).ConfigureAwait(false);
             return setResult ? result : new CallResult<UpdateSubscription>(setResult.Error!);
         }
@@ -83,6 +87,10 @@ namespace CoinEx.Net.SymbolOrderBooks
         /// <inheritdoc />
         protected override async Task<CallResult<bool>> DoResyncAsync(CancellationToken ct)
         {
+            // Query the initial order book
+            var initialBook = await _socketClient.SpotApi.GetOrderBookAsync(Symbol, Levels!.Value, 0).ConfigureAwait(false);
+            SetInitialOrderBook(DateTime.UtcNow.Ticks, initialBook.Data.Bids, initialBook.Data.Asks);
+
             return await WaitForSetOrderBookAsync(_initialDataTimeout, ct).ConfigureAwait(false);
         }
 

--- a/CoinEx.Net/SymbolOrderBooks/CoinExSpotSymbolOrderBook.cs
+++ b/CoinEx.Net/SymbolOrderBooks/CoinExSpotSymbolOrderBook.cs
@@ -64,7 +64,7 @@ namespace CoinEx.Net.SymbolOrderBooks
         /// <inheritdoc />
         protected override async Task<CallResult<UpdateSubscription>> DoStartAsync(CancellationToken ct)
         {
-            var result = await _socketClient.SpotApi.SubscribeToOrderBookUpdatesAsync(Symbol, Levels!.Value, 0, HandleUpdate).ConfigureAwait(false);
+            var result = await _socketClient.SpotApi.SubscribeToOrderBookUpdatesAsync(Symbol, Levels!.Value, 0, HandleUpdate, diffUpdates: true).ConfigureAwait(false);
             if (!result)
                 return result;
 


### PR DESCRIPTION
The initial snapshot for the `depth.subscribe` subscription doesn't come before any changes in the order book happen.
The issue that the order book may timeout before the initial book is received, and you have no order book available until this happens.

Changed `CoinExDepthSubscription` params to get diff updates instead of snapshot updates