### PR TITLE
Configure HttpClient initialization to default system proxy for sending HTTP requests

### DIFF
--- a/CoinEx.Net/ExtensionMethods/ServiceCollectionExtensions.cs
+++ b/CoinEx.Net/ExtensionMethods/ServiceCollectionExtensions.cs
@@ -113,6 +113,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 try
                 {
                     handler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+                    handler.UseDefaultCredentials = true;
+                    handler.DefaultProxyCredentials = CredentialCache.DefaultCredentials;
                 }
                 catch (PlatformNotSupportedException)
                 { }


### PR DESCRIPTION
The code in the `ServiceCollectionExtensions.cs` has been updated to improve library's integration with system.

The previous behaviour for the library was ignoring the OS system-wide proxy settings, and always sending HTTP Requests directly. The code is updated so now if the OS supports this functionality and a system-wide proxy has been set, the library will also try to tunnel its HTTP requests through that.