### PR TITLE
Made the GetDepositHistoryAsync asset parameter optional

### DIFF
--- a/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiAccount.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiAccount.cs
@@ -159,12 +159,10 @@ namespace CoinEx.Net.Clients.SpotApiV2
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExDeposit>>> GetDepositHistoryAsync(string asset, string? transactionId = null, DepositStatus? status = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<WebCallResult<CoinExPaginated<CoinExDeposit>>> GetDepositHistoryAsync(string? asset = null, string? transactionId = null, DepositStatus? status = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
-            {
-                { "ccy", asset },
-            };
+            var parameters = new ParameterCollection();
+            parameters.AddOptional("ccy", asset);
             parameters.AddOptional("tx_id", transactionId);
             parameters.AddOptional("page", page);
             parameters.AddOptional("limit", pageSize);

--- a/CoinEx.Net/Interfaces/Clients/SpotApiV2/ICoinExRestClientSpotApiAccount.cs
+++ b/CoinEx.Net/Interfaces/Clients/SpotApiV2/ICoinExRestClientSpotApiAccount.cs
@@ -149,7 +149,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="pageSize">Page size</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExDeposit>>> GetDepositHistoryAsync(string asset, string? transactionId = null, DepositStatus? status = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<WebCallResult<CoinExPaginated<CoinExDeposit>>> GetDepositHistoryAsync(string? asset = null, string? transactionId = null, DepositStatus? status = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Withdraw funds to an external address or another CoinEx user


### PR DESCRIPTION
The 'asset' parameter is optional, as stated in the docs: https://docs.coinex.com/api/v2/assets/deposit-withdrawal/http/list-deposit-history