### PR TITLE
CryptoExchange.Net V12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ description: Use CoinEx.Net when generating C#/.NET code that interacts with the
 
 If the user asks for CoinEx API access in C#/.NET, **use CoinEx.Net**. Do not write raw `HttpClient` calls to CoinEx endpoints. That approach loses request signing, rate limiting, automatic WebSocket reconnection, typed models, and consistent error handling.
 
-For multi-exchange code, additionally use `CryptoExchange.Net.SharedApis` interfaces. CoinEx exposes shared clients for both Spot V2 and Futures.
+For multi-exchange code, additionally use `CryptoExchange.Net.SharedApis` interfaces. CoinEx exposes shared clients for both Spot V2 and Futures. Use `.SharedClient.Discover()` to inspect supported shared features at runtime.
 
 ## Installation
 
@@ -41,7 +41,7 @@ var publicClient = new CoinExRestClient();
 
 ## Core Pattern: Result Handling
 
-REST methods return `HttpResult<T>` or `HttpResult`. WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`. Always check `.Success` before accessing `.Data`.
+REST methods return `HttpResult<T>` or `HttpResult`. WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`. Shared non-I/O symbol/cache helpers return `ExchangeCallResult<T>`. Always check `.Success` before accessing `.Data`.
 
 ```csharp
 var tickers = await restClient.SpotApiV2.ExchangeData.GetTickersAsync(new[] { "BTCUSDT" });
@@ -159,6 +159,9 @@ using CoinEx.Net.Clients;
 using CryptoExchange.Net.SharedApis;
 
 var coinexShared = new CoinExRestClient().SpotApiV2.SharedClient;
+var info = coinexShared.Discover();
+Console.WriteLine(info);
+
 var symbol = new SharedSymbol(TradingMode.Spot, "BTC", "USDT");
 
 var ticker = await coinexShared.GetSpotTickerAsync(new GetTickerRequest(symbol));

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ var publicClient = new CoinExRestClient();
 
 ## Core Pattern: Result Handling
 
-REST methods return `WebCallResult<T>` or `WebCallResult`. WebSocket subscriptions return `CallResult<UpdateSubscription>`. Always check `.Success` before accessing `.Data`.
+REST methods return `HttpResult<T>` or `HttpResult`. WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`. Always check `.Success` before accessing `.Data`.
 
 ```csharp
 var tickers = await restClient.SpotApiV2.ExchangeData.GetTickersAsync(new[] { "BTCUSDT" });

--- a/CoinEx.Net.UnitTests/CoinExClientTests.cs
+++ b/CoinEx.Net.UnitTests/CoinExClientTests.cs
@@ -34,7 +34,7 @@ namespace CoinEx.Net.UnitTests
                     return headers["X-COINEX-SIGN"].ToString();
                 },
                 "444976F4F21D422AB7091B47D9201EB02A6614FF1F4C7B9F6CA57BFF632030A5",
-                new Dictionary<string, object>
+                new Parameters(CoinExExchange._parameterSerializationSettings)
                 {
                     { "market", "BTCUSDT" },
                     { "market_type", "SPOT" },
@@ -42,8 +42,7 @@ namespace CoinEx.Net.UnitTests
                     { "page", "1" },
                     { "limit", "10" },
                 },
-                time: DateTimeConverter.ParseFromDouble(1700490704564),
-                disableOrdering: true);
+                time: DateTimeConverter.ParseFromDouble(1700490704564));
         }
 
         [Test]
@@ -64,7 +63,7 @@ namespace CoinEx.Net.UnitTests
                     return headers["X-COINEX-SIGN"].ToString();
                 },
                 "5128936CEDB75A512991A47BCCB0A78F6D9F6F540C07A17AE68D31F16E06A17F",
-                new Dictionary<string, object>
+                new Parameters(CoinExExchange._parameterSerializationSettings)
                 {
                     { "market", "BTCUSDT" },
                     { "market_type", "SPOT" },
@@ -72,8 +71,7 @@ namespace CoinEx.Net.UnitTests
                     { "page", "1" },
                     { "limit", "10" },
                 },
-                time: DateTimeConverter.ParseFromDouble(1700490704564),
-                disableOrdering: true);
+                time: DateTimeConverter.ParseFromDouble(1700490704564));
         }
 
         [Test]

--- a/CoinEx.Net.UnitTests/RestRequestTests.cs
+++ b/CoinEx.Net.UnitTests/RestRequestTests.cs
@@ -174,7 +174,7 @@ namespace CoinEx.Net.UnitTests
             await tester.ValidateAsync(client => client.FuturesApi.Trading.GetAutoSettlementHistoryAsync("ETHUSDT", 1), "GetAutoSettlementHistory");
         }
 
-        private bool IsAuthenticated(WebCallResult result)
+        private bool IsAuthenticated(IHttpResult result)
         {
             return result.RequestHeaders.Any(x => x.Key == "X-COINEX-KEY");
         }

--- a/CoinEx.Net.UnitTests/SocketSubscriptionTests.cs
+++ b/CoinEx.Net.UnitTests/SocketSubscriptionTests.cs
@@ -26,7 +26,7 @@ namespace CoinEx.Net.UnitTests
                 OutputOriginalData = true
             }), logger);
 
-            var tester = new SocketSubscriptionValidator<CoinExSocketClient>(client, "Subscriptions/SpotApi", "wss://socket.coinex.com", "data");
+            var tester = new SocketSubscriptionValidator<CoinExSocketClient>(client, "Subscriptions/SpotApi", "wss://socket.coinex.com/v2/spot", "data");
             await tester.ValidateConcurrentAsync<CoinExTrade[]>(
                 (client, handler) => client.SpotApiV2.SubscribeToTradeUpdatesAsync("ETHUSDT", handler),
                 (client, handler) => client.SpotApiV2.SubscribeToTradeUpdatesAsync("BTCUSDT", handler),

--- a/CoinEx.Net/Clients/CoinExRestClient.cs
+++ b/CoinEx.Net/Clients/CoinExRestClient.cs
@@ -43,8 +43,8 @@ namespace CoinEx.Net.Clients
         {
             Initialize(options.Value);
 
-            FuturesApi = AddApiClient(new CoinExRestClientFuturesApi(_logger, httpClient, options.Value));
-            SpotApiV2 = AddApiClient(new SpotApiV2.CoinExRestClientSpotApi(_logger, httpClient, options.Value));
+            FuturesApi = AddApiClient(new CoinExRestClientFuturesApi(loggerFactory, httpClient, options.Value));
+            SpotApiV2 = AddApiClient(new SpotApiV2.CoinExRestClientSpotApi(loggerFactory, httpClient, options.Value));
         }
         #endregion
 

--- a/CoinEx.Net/Clients/CoinExSocketClient.cs
+++ b/CoinEx.Net/Clients/CoinExSocketClient.cs
@@ -43,8 +43,8 @@ namespace CoinEx.Net.Clients
         {
             Initialize(options.Value);
 
-            FuturesApi = AddApiClient(new CoinExSocketClientFuturesApi(_logger, options.Value));
-            SpotApiV2 = AddApiClient(new SpotApiV2.CoinExSocketClientSpotApi(_logger, options.Value));
+            FuturesApi = AddApiClient(new CoinExSocketClientFuturesApi(loggerFactory, options.Value));
+            SpotApiV2 = AddApiClient(new SpotApiV2.CoinExSocketClientSpotApi(loggerFactory, options.Value));
         }
         #endregion
 

--- a/CoinEx.Net/Clients/CoinExUserClientProvider.cs
+++ b/CoinEx.Net/Clients/CoinExUserClientProvider.cs
@@ -1,6 +1,7 @@
 ﻿using CoinEx.Net.Interfaces.Clients;
 using CoinEx.Net.Objects.Options;
 using CryptoExchange.Net.Authentication;
+using CryptoExchange.Net.Clients;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -12,18 +13,17 @@ using System.Net.Http;
 namespace CoinEx.Net.Clients
 {
     /// <inheritdoc />
-    public class CoinExUserClientProvider : ICoinExUserClientProvider
+    public class CoinExUserClientProvider : UserClientProvider<
+        ICoinExRestClient,
+        ICoinExSocketClient,
+        CoinExRestOptions,
+        CoinExSocketOptions,
+        CoinExCredentials,
+        CoinExEnvironment
+        >, ICoinExUserClientProvider
     {
-        private ConcurrentDictionary<string, ICoinExRestClient> _restClients = new ConcurrentDictionary<string, ICoinExRestClient>();
-        private ConcurrentDictionary<string, ICoinExSocketClient> _socketClients = new ConcurrentDictionary<string, ICoinExSocketClient>();
-
-        private readonly IOptions<CoinExRestOptions> _restOptions;
-        private readonly IOptions<CoinExSocketOptions> _socketOptions;
-        private readonly HttpClient _httpClient;
-        private readonly ILoggerFactory? _loggerFactory;
-
         /// <inheritdoc />
-        public string ExchangeName => CoinExExchange.ExchangeName;
+        public override string ExchangeName => CoinExExchange.ExchangeName;
 
         /// <summary>
         /// ctor
@@ -42,97 +42,15 @@ namespace CoinEx.Net.Clients
             ILoggerFactory? loggerFactory,
             IOptions<CoinExRestOptions> restOptions,
             IOptions<CoinExSocketOptions> socketOptions)
+            : base(httpClient, loggerFactory, restOptions, socketOptions)
         {
-            _httpClient = httpClient ?? new HttpClient();
-            _httpClient.Timeout = restOptions.Value.RequestTimeout;
-            _loggerFactory = loggerFactory;
-            _restOptions = restOptions;
-            _socketOptions = socketOptions;
         }
 
         /// <inheritdoc />
-        public void InitializeUserClient(string userIdentifier, CoinExCredentials credentials, CoinExEnvironment? environment = null)
-        {
-            CreateRestClient(userIdentifier, credentials, environment);
-            CreateSocketClient(userIdentifier, credentials, environment);
-        }
-
+        protected override ICoinExRestClient ConstructRestClient(HttpClient client, ILoggerFactory? loggerFactory, IOptions<CoinExRestOptions> options)
+            => new CoinExRestClient(client, loggerFactory, options);
         /// <inheritdoc />
-        public void ClearUserClients(string userIdentifier)
-        {
-            _restClients.TryRemove(userIdentifier, out _);
-            _socketClients.TryRemove(userIdentifier, out _);
-        }
-
-        /// <inheritdoc />
-        public ICoinExRestClient GetRestClient(string userIdentifier, CoinExCredentials? credentials = null, CoinExEnvironment? environment = null)
-        {
-            if (!_restClients.TryGetValue(userIdentifier, out var client) || client.Disposed)
-                client = CreateRestClient(userIdentifier, credentials, environment);
-
-            return client;
-        }
-
-        /// <inheritdoc />
-        public ICoinExSocketClient GetSocketClient(string userIdentifier, CoinExCredentials? credentials = null, CoinExEnvironment? environment = null)
-        {
-            if (!_socketClients.TryGetValue(userIdentifier, out var client) || client.Disposed)
-                client = CreateSocketClient(userIdentifier, credentials, environment);
-
-            return client;
-        }
-
-        private ICoinExRestClient CreateRestClient(string userIdentifier, CoinExCredentials? credentials, CoinExEnvironment? environment)
-        {
-            var clientRestOptions = SetRestEnvironment(environment);
-            var client = new CoinExRestClient(_httpClient, _loggerFactory, clientRestOptions);
-            if (credentials != null)
-            {
-                client.SetApiCredentials(credentials);
-                _restClients[userIdentifier] = client;
-            }
-            return client;
-        }
-
-        private ICoinExSocketClient CreateSocketClient(string userIdentifier, CoinExCredentials? credentials, CoinExEnvironment? environment)
-        {
-            var clientSocketOptions = SetSocketEnvironment(environment);
-            var client = new CoinExSocketClient(clientSocketOptions!, _loggerFactory);
-            if (credentials != null)
-            {
-                client.SetApiCredentials(credentials);
-                _socketClients[userIdentifier] = client;
-            }
-            return client;
-        }
-
-        private IOptions<CoinExRestOptions> SetRestEnvironment(CoinExEnvironment? environment)
-        {
-            if (environment == null)
-                return _restOptions;
-
-            var newRestClientOptions = new CoinExRestOptions();
-            var restOptions = _restOptions.Value.Set(newRestClientOptions);
-            newRestClientOptions.Environment = environment;
-            return Options.Create(newRestClientOptions);
-        }
-
-        private IOptions<CoinExSocketOptions> SetSocketEnvironment(CoinExEnvironment? environment)
-        {
-            if (environment == null)
-                return _socketOptions;
-
-            var newSocketClientOptions = new CoinExSocketOptions();
-            var restOptions = _socketOptions.Value.Set(newSocketClientOptions);
-            newSocketClientOptions.Environment = environment;
-            return Options.Create(newSocketClientOptions);
-        }
-
-        private static T ApplyOptionsDelegate<T>(Action<T>? del) where T : new()
-        {
-            var opts = new T();
-            del?.Invoke(opts);
-            return opts;
-        }
+        protected override ICoinExSocketClient ConstructSocketClient(ILoggerFactory? loggerFactory, IOptions<CoinExSocketOptions> options)
+            => new CoinExSocketClient(options, loggerFactory);
     }
 }

--- a/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApi.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApi.cs
@@ -34,9 +34,6 @@ namespace CoinEx.Net.Clients.FuturesApi
         protected override ErrorMapping ErrorMapping => CoinExErrors.RestErrorMapping;
         #endregion
 
-        /// <inheritdoc />
-        public string ExchangeName => "CoinEx";
-
         #region Api clients
         /// <inheritdoc />
         public ICoinExRestClientFuturesApiAccount Account { get; }
@@ -47,8 +44,8 @@ namespace CoinEx.Net.Clients.FuturesApi
         #endregion
 
         #region ctor
-        internal CoinExRestClientFuturesApi(ILogger logger, HttpClient? httpClient, CoinExRestOptions options) :
-            base(logger, CoinExExchange.Metadata.Id, httpClient, options.Environment.RestBaseAddress, options, options.FuturesOptions)
+        internal CoinExRestClientFuturesApi(ILoggerFactory? loggerFactory, HttpClient? httpClient, CoinExRestOptions options) :
+            base(loggerFactory, CoinExExchange.Metadata.Id, httpClient, options.Environment.RestBaseAddress, options, options.FuturesOptions)
         {
             Account = new CoinExRestClientFuturesApiAccount(this);
             ExchangeData = new CoinExRestClientFuturesApiExchangeData(this);

--- a/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApi.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApi.cs
@@ -48,7 +48,7 @@ namespace CoinEx.Net.Clients.FuturesApi
 
         #region ctor
         internal CoinExRestClientFuturesApi(ILogger logger, HttpClient? httpClient, CoinExRestOptions options) :
-            base(logger, httpClient, options.Environment.RestBaseAddress, options, options.FuturesOptions)
+            base(logger, CoinExExchange.Metadata.Id, httpClient, options.Environment.RestBaseAddress, options, options.FuturesOptions)
         {
             Account = new CoinExRestClientFuturesApiAccount(this);
             ExchangeData = new CoinExRestClientFuturesApiExchangeData(this);
@@ -75,44 +75,38 @@ namespace CoinEx.Net.Clients.FuturesApi
 
         #region methods
 
-        internal Task<WebCallResult> SendAsync(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
-            => SendToAddressAsync(BaseAddress, definition, parameters, cancellationToken, weight);
-
-        internal async Task<WebCallResult> SendToAddressAsync(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<HttpResult> SendAsync(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
-            var result = await base.SendAsync<CoinExApiResult>(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
-            if (!result)
-                return result.AsDataless();
+            var result = await base.SendAsync<CoinExApiResult>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+            if (!result.Success)
+                return result;
 
             if (result.Data.Code != 0)
-                return result.AsDatalessError(new ServerError(result.Data.Code, GetErrorInfo(result.Data.Code, result.Data.Message!)));
+                return HttpResult.Fail(result, new ServerError(result.Data.Code, GetErrorInfo(result.Data.Code, result.Data.Message!)));
 
-            return result.AsDataless();
+            return result;
         }
 
-        internal Task<WebCallResult<T>> SendAsync<T>(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
-            => SendToAddressAsync<T>(BaseAddress, definition, parameters, cancellationToken, weight);
-
-        internal async Task<WebCallResult<T>> SendToAddressAsync<T>(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
+        internal async Task<HttpResult<T>> SendAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
         {
-            var result = await base.SendAsync<CoinExApiResult<T>>(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
-            if (!result)
-                return result.As<T>(default);
+            var result = await base.SendAsync<CoinExApiResult<T>>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+            if (!result.Success)
+                return HttpResult.Fail<T>(result);
 
             if (result.Data.Code != 0)
-                return result.AsError<T>(new ServerError(result.Data.Code, GetErrorInfo(result.Data.Code, result.Data.Message!)));
+                return HttpResult.Fail<T>(result, new ServerError(result.Data.Code, GetErrorInfo(result.Data.Code, result.Data.Message!)));
 
-            return result.As(result.Data.Data);
+            return HttpResult.Ok(result, result.Data.Data);
         }
 
-        internal async Task<WebCallResult<CoinExPaginated<T>>> SendPaginatedAsync<T>(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
+        internal async Task<HttpResult<CoinExPaginated<T>>> SendPaginatedAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
         {
-            var result = await base.SendAsync<CoinExPageApiResult<T[]>>(BaseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
-            if (!result)
-                return result.As<CoinExPaginated<T>>(default);
+            var result = await base.SendAsync<CoinExPageApiResult<T[]>>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+            if (!result.Success)
+                return HttpResult.Fail<CoinExPaginated<T>>(result);
 
             if (result.Data.Code != 0)
-                return result.AsError<CoinExPaginated<T>>(new ServerError(result.Data.Code, GetErrorInfo(result.Data.Code, result.Data.Message!)));
+                return HttpResult.Fail<CoinExPaginated<T>>(result, new ServerError(result.Data.Code, GetErrorInfo(result.Data.Code, result.Data.Message!)));
 
             var resultPage = new CoinExPaginated<T>
             {
@@ -121,12 +115,12 @@ namespace CoinEx.Net.Clients.FuturesApi
                 Items = result.Data.Data
             };
 
-            return result.As(resultPage);
+            return HttpResult.Ok(result, resultPage);
         }
         #endregion
 
         /// <inheritdoc />
-        protected override async Task<WebCallResult<DateTime>> GetServerTimestampAsync() => await ExchangeData.GetServerTimeAsync().ConfigureAwait(false);
+        protected override async Task<HttpResult<DateTime>> GetServerTimestampAsync() => await ExchangeData.GetServerTimeAsync().ConfigureAwait(false);
 
     }
 }

--- a/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiAccount.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiAccount.cs
@@ -22,39 +22,39 @@ namespace CoinEx.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExTradeFee>> GetTradingFeesAsync(string symbol, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExTradeFee>> GetTradingFeesAsync(string symbol, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/account/trade-fee-rate", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/account/trade-fee-rate", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
             return await _baseClient.SendAsync<CoinExTradeFee>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExFuturesBalance[]>> GetBalancesAsync(CancellationToken ct = default)
+        public async Task<HttpResult<CoinExFuturesBalance[]>> GetBalancesAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/assets/futures/balance", CoinExExchange.RateLimiter.CoinExRestFuturesAccount, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/assets/futures/balance", CoinExExchange.RateLimiter.CoinExRestFuturesAccount, 1, true);
             var result = await _baseClient.SendAsync<CoinExFuturesBalance[]>(request, null, ct).ConfigureAwait(false);
-            if (result && result.Data == null)
-                return result.As<CoinExFuturesBalance[]>(Array.Empty<CoinExFuturesBalance>());
+            if (result.Success && result.Data == null)
+                return HttpResult.Ok<CoinExFuturesBalance[]>(result, Array.Empty<CoinExFuturesBalance>());
 
             return result;
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExLeverage>> SetLeverageAsync(string symbol, MarginMode mode, int leverage, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExLeverage>> SetLeverageAsync(string symbol, MarginMode mode, int leverage, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "leverage", leverage }
             };
-            parameters.AddEnum("market_Type", AccountType.Futures);
-            parameters.AddEnum("margin_mode", mode);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/adjust-position-leverage", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
+            parameters.Add("market_Type", AccountType.Futures);
+            parameters.Add("margin_mode", mode);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/adjust-position-leverage", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
             return await _baseClient.SendAsync<CoinExLeverage>(request, parameters, ct).ConfigureAwait(false);
         }
     }

--- a/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiExchangeData.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiExchangeData.cs
@@ -22,59 +22,61 @@ namespace CoinEx.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default)
+        public async Task<HttpResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/time", CoinExExchange.RateLimiter.CoinExRestPublic);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/time", CoinExExchange.RateLimiter.CoinExRestPublic);
             var result = await _baseClient.SendAsync<CoinExServerTime>(request, null, ct).ConfigureAwait(false);
-            return result.As(result.Data?.ServerTime ?? default);
+            if (!result.Success)
+                return HttpResult.Fail<DateTime>(result);
+            return HttpResult.Ok(result, result.Data.ServerTime);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExFuturesSymbol[]>> GetSymbolsAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExFuturesSymbol[]>> GetSymbolsAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbols == null ? null :string.Join(",", symbols));
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/market", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market", symbols == null ? null :string.Join(",", symbols));
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/market", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
             return await _baseClient.SendAsync<CoinExFuturesSymbol[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExFuturesTicker[]>> GetTickersAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExFuturesTicker[]>> GetTickersAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbols == null ? null : string.Join(",", symbols));
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/ticker", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market", symbols == null ? null : string.Join(",", symbols));
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/ticker", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
             return await _baseClient.SendAsync<CoinExFuturesTicker[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExOrderBook>> GetOrderBookAsync(string symbol, int limit, string? mergeLevel = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExOrderBook>> GetOrderBookAsync(string symbol, int limit, string? mergeLevel = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "limit", limit },
                 { "interval", mergeLevel ?? "0" }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/depth", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/depth", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
             return await _baseClient.SendAsync<CoinExOrderBook>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExTrade[]>> GetTradeHistoryAsync(string symbol, int? limit = null, long? lastId = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExTrade[]>> GetTradeHistoryAsync(string symbol, int? limit = null, long? lastId = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptional("last_id", lastId);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/deals", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
+            parameters.Add("limit", limit);
+            parameters.Add("last_id", lastId);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/deals", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
             return await _baseClient.SendAsync<CoinExTrade[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExKline[]>> GetKlinesAsync(
+        public async Task<HttpResult<CoinExKline[]>> GetKlinesAsync(
             string symbol, 
             KlineInterval interval,
             int? limit = null,
@@ -83,101 +85,101 @@ namespace CoinEx.Net.Clients.FuturesApi
             DateTime? endTime = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddEnum("period", interval);
-            parameters.AddOptionalEnum("price_type", priceType);
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptionalMilliseconds("start_time", startTime);
-            parameters.AddOptionalMilliseconds("end_time", endTime);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/kline", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
+            parameters.Add("period", interval);
+            parameters.Add("price_type", priceType);
+            parameters.Add("limit", limit);
+            parameters.Add("start_time", startTime);
+            parameters.Add("end_time", endTime);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/kline", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
             return await _baseClient.SendAsync<CoinExKline[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExIndexPrice[]>> GetIndexPricesAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExIndexPrice[]>> GetIndexPricesAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbols == null ? null : string.Join(",", symbols));
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/index", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market", symbols == null ? null : string.Join(",", symbols));
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/index", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
             return await _baseClient.SendAsync<CoinExIndexPrice[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExFundingRate[]>> GetFundingRatesAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExFundingRate[]>> GetFundingRatesAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbols == null ? null : string.Join(",", symbols));
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/funding-rate", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market", symbols == null ? null : string.Join(",", symbols));
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/funding-rate", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
             return await _baseClient.SendAsync<CoinExFundingRate[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExFundingRateHistory>>> GetFundingRateHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExFundingRateHistory>>> GetFundingRateHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddOptionalMilliseconds("start_time", startTime);
-            parameters.AddOptionalMilliseconds("end_time", endTime);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/funding-rate-history", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
+            parameters.Add("start_time", startTime);
+            parameters.Add("end_time", endTime);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/funding-rate-history", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
             return await _baseClient.SendPaginatedAsync<CoinExFundingRateHistory>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPremiumIndexHistory[]>> GetPremiumIndexPriceHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPremiumIndexHistory[]>> GetPremiumIndexPriceHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddOptionalMilliseconds("start_time", startTime);
-            parameters.AddOptionalMilliseconds("end_time", endTime);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/premium-index-history", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
+            parameters.Add("start_time", startTime);
+            parameters.Add("end_time", endTime);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/premium-index-history", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
             return await _baseClient.SendAsync<CoinExPremiumIndexHistory[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPositionLevels[]>> GetPositionLevelsAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPositionLevels[]>> GetPositionLevelsAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbols == null ? null : string.Join(",", symbols));
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/position-level", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market", symbols == null ? null : string.Join(",", symbols));
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/position-level", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
             return await _baseClient.SendAsync<CoinExPositionLevels[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExLiquidation>>> GetLiquidationHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExLiquidation>>> GetLiquidationHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddOptionalMilliseconds("start_time", startTime);
-            parameters.AddOptionalMilliseconds("end_time", endTime);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/liquidation-history", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
+            parameters.Add("start_time", startTime);
+            parameters.Add("end_time", endTime);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/liquidation-history", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
             return await _baseClient.SendPaginatedAsync<CoinExLiquidation>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExBasis[]>> GetBasisHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExBasis[]>> GetBasisHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddOptionalMilliseconds("start_time", startTime);
-            parameters.AddOptionalMilliseconds("end_time", endTime);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/basis-history", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
+            parameters.Add("start_time", startTime);
+            parameters.Add("end_time", endTime);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/basis-history", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false);
             return await _baseClient.SendAsync<CoinExBasis[]>(request, parameters, ct).ConfigureAwait(false);
         }
     }

--- a/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiShared.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiShared.cs
@@ -22,7 +22,7 @@ namespace CoinEx.Net.Clients.FuturesApi
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
-        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(CoinExExchange.Metadata, this);
 
         #region Balance Client
         GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(_exchangeName, AccountTypeFilter.Futures);
@@ -65,7 +65,7 @@ namespace CoinEx.Net.Clients.FuturesApi
             if (ticker == null || funding == null)
                 return HttpResult.Fail<SharedFuturesTicker>(resultTicker.Result, new ServerError(new ErrorInfo(ErrorType.Unknown, "Not found")));
 
-            return HttpResult.Ok(resultTicker.Result, new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, ticker.Symbol), ticker.Symbol, ticker.LastPrice, ticker.HighPrice, ticker.LowPrice, ticker.Volume, ticker.OpenPrice == 0 ? null : Math.Round(ticker.LastPrice / ticker.OpenPrice * 100 - 100, 2))
+            return HttpResult.Ok(resultTicker.Result, new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, ticker.Symbol), ticker.Symbol, ticker.LastPrice, ticker.HighPrice, ticker.LowPrice, ticker.Volume, ticker.OpenPrice == 0 ? null : Math.Round(ticker.LastPrice / ticker.OpenPrice * 100 - 100, 2))
             {
                 IndexPrice = ticker.IndexPrice,
                 MarkPrice = ticker.MarkPrice,
@@ -92,7 +92,7 @@ namespace CoinEx.Net.Clients.FuturesApi
             return HttpResult.Ok(resultTickers.Result, resultTickers.Result.Data.Select(x =>
             {
                 var funding = resultFunding.Result.Data.Single(p => p.Symbol == x.Symbol);
-                return new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.OpenPrice == 0 ? null : Math.Round(x.LastPrice / x.OpenPrice * 100 - 100, 2))
+                return new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.OpenPrice == 0 ? null : Math.Round(x.LastPrice / x.OpenPrice * 100 - 100, 2))
                 {
                     IndexPrice = x.IndexPrice,
                     MarkPrice = x.MarkPrice,
@@ -118,7 +118,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                 return HttpResult.Fail<SharedBookTicker>(resultTicker);
 
             return HttpResult.Ok(resultTicker, new SharedBookTicker(
-                ExchangeSymbolCache.ParseSymbol(_topicId, resultTicker.Data.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, resultTicker.Data.Symbol),
                 resultTicker.Data.Symbol,
                 resultTicker.Data.Data.Asks[0].Price,
                 resultTicker.Data.Data.Asks[0].Quantity,
@@ -158,19 +158,19 @@ namespace CoinEx.Net.Clients.FuturesApi
                 ContractSize = 1
             }).ToArray());
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, response.Data!);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, response.Data!);
             return response;
         }
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicId))
+            if (!ExchangeSymbolCache.HasCached(_topicId, EnvironmentName, null))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, EnvironmentName, null, baseAsset));
         }
 
         async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
@@ -178,26 +178,26 @@ namespace CoinEx.Net.Clients.FuturesApi
             if (symbol.TradingMode == TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Spot symbols not allowed");
 
-            if (!ExchangeSymbolCache.HasCached(_topicId))
+            if (!ExchangeSymbolCache.HasCached(_topicId, EnvironmentName, null))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, EnvironmentName, null, symbol));
         }
 
         async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicId))
+            if (!ExchangeSymbolCache.HasCached(_topicId, EnvironmentName, null))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, EnvironmentName, null, symbolName));
         }
         #endregion
 
@@ -252,7 +252,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                 return HttpResult.Fail<SharedFuturesOrder>(order);
 
             return HttpResult.Ok(order, new SharedFuturesOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicId, order.Data.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, order.Data.Symbol),
                 order.Data.Symbol,
                 order.Data.Id.ToString(),
                 ParseOrderType(order.Data.OrderType),
@@ -284,7 +284,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                 return HttpResult.Fail<SharedFuturesOrder[]>(orders);
 
             return HttpResult.Ok(orders, orders.Data.Items.Select(x => new SharedFuturesOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol), 
                 x.Symbol,
                 x.Id.ToString(),
                 ParseOrderType(x.OrderType),
@@ -335,7 +335,7 @@ namespace CoinEx.Net.Clients.FuturesApi
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                     .Select(x => 
                         new SharedFuturesOrder(
-                            ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
+                            ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol), 
                             x.Symbol,
                             x.Id.ToString(),
                             ParseOrderType(x.OrderType),
@@ -369,7 +369,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                 return HttpResult.Fail<SharedUserTrade[]>(orders);
 
             return HttpResult.Ok(orders, orders.Data.Items.Select(x => new SharedUserTrade(
-                ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString(),
                 x.Id.ToString(),
@@ -420,7 +420,7 @@ namespace CoinEx.Net.Clients.FuturesApi
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                     .Select(x =>
                         new SharedUserTrade(
-                            ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
+                            ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol), 
                             x.Symbol,
                             x.OrderId.ToString(),
                             x.Id.ToString(),
@@ -464,7 +464,7 @@ namespace CoinEx.Net.Clients.FuturesApi
             if (!result.Success)
                 return HttpResult.Fail<SharedPosition[]>(result);
 
-            return HttpResult.Ok(result, result.Data.Items.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.OpenInterest, x.UpdateTime)
+            return HttpResult.Ok(result, result.Data.Items.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol), x.Symbol, x.OpenInterest, x.UpdateTime)
             {
                 UnrealizedPnl = x.UnrealizedPnl,
                 LiquidationPrice = x.LiquidationPrice,
@@ -572,7 +572,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                 return HttpResult.Fail<SharedFuturesOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
             return HttpResult.Ok(order, new SharedFuturesOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicId, orderData.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, orderData.Symbol),
                 orderData.Symbol,
                 orderData.Id.ToString(),
                 ParseOrderType(orderData.OrderType),
@@ -960,7 +960,7 @@ namespace CoinEx.Net.Clients.FuturesApi
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                    .Select(x => 
                         new SharedPositionHistory(
-                            ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
+                            ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol),
                             x.Symbol,
                             x.Side == PositionSide.Long ? SharedPositionSide.Long : SharedPositionSide.Short,
                             x.AverageEntryPrice,
@@ -1057,7 +1057,7 @@ namespace CoinEx.Net.Clients.FuturesApi
             }
 
             return HttpResult.Ok(orders, new SharedFuturesTriggerOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicId, order.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, order.Symbol),
                 order.Symbol,
                 order.ClientOrderId?.ToString() ?? order.StopOrderId.ToString(),
                 ParseOrderType(order.Type),

--- a/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiShared.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiShared.cs
@@ -37,7 +37,12 @@ namespace CoinEx.Net.Clients.FuturesApi
             if (!result.Success)
                 return HttpResult.Fail<SharedBalance[]>(result);
 
-            return HttpResult.Ok(result, result.Data.Select(x => new SharedBalance(x.Asset, x.Available, x.Available + x.Frozen)).ToArray());
+            return HttpResult.Ok(result, result.Data.Select(x => 
+                new SharedBalance(
+                    SupportedTradingModes, 
+                    x.Asset,
+                    x.Available,
+                    x.Available + x.Frozen)).ToArray());
         }
 
         #endregion

--- a/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiShared.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiShared.cs
@@ -17,54 +17,55 @@ namespace CoinEx.Net.Clients.FuturesApi
     internal partial class CoinExRestClientFuturesApi : ICoinExRestClientFuturesApiShared
     {
         private const string _topicId = "CoinExFutures";
-        public string Exchange => CoinExExchange.ExchangeName;
-        public TradingMode[] SupportedTradingModes { get; } = new[] { TradingMode.PerpetualLinear, TradingMode.PerpetualInverse };
+        private const string _exchangeName = "CoinEx";
+        public TradingMode[] SupportedTradingModes => new[] { TradingMode.PerpetualLinear, TradingMode.PerpetualInverse };
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
 
         #region Balance Client
-        GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(AccountTypeFilter.Futures);
+        GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(_exchangeName, AccountTypeFilter.Futures);
 
-        async Task<ExchangeWebResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
         {
-            var validationError = ((IBalanceRestClient)this).GetBalancesOptions.ValidateRequest(Exchange, request, SupportedTradingModes);
+            var validationError = SharedClient.GetBalancesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedBalance[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedBalance[]>(Exchange, validationError);
 
             var result = await Account.GetBalancesAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedBalance[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedBalance[]>(result);
 
-            return result.AsExchangeResult<SharedBalance[]>(Exchange, SupportedTradingModes, result.Data.Select(x => new SharedBalance(x.Asset, x.Available, x.Available + x.Frozen)).ToArray());
+            return HttpResult.Ok(result, result.Data.Select(x => new SharedBalance(x.Asset, x.Available, x.Available + x.Frozen)).ToArray());
         }
 
         #endregion
 
         #region Ticker client
 
-        GetTickerOptions IFuturesTickerRestClient.GetFuturesTickerOptions { get; } = new GetTickerOptions();
-        async Task<ExchangeWebResult<SharedFuturesTicker>> IFuturesTickerRestClient.GetFuturesTickerAsync(GetTickerRequest request, CancellationToken ct)
+        GetFuturesTickerOptions IFuturesTickerRestClient.GetFuturesTickerOptions { get; } = new GetFuturesTickerOptions(_exchangeName);
+        async Task<HttpResult<SharedFuturesTicker>> IFuturesTickerRestClient.GetFuturesTickerAsync(GetTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTickerRestClient)this).GetFuturesTickerOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesTicker>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesTicker>(Exchange, validationError);
 
             var resultTicker = ExchangeData.GetTickersAsync(new[] { request.Symbol!.GetSymbol(FormatSymbol) }, ct: ct);
             var resultFunding = ExchangeData.GetFundingRatesAsync(new[] { request.Symbol!.GetSymbol(FormatSymbol) }, ct: ct);
             await Task.WhenAll(resultTicker, resultFunding).ConfigureAwait(false);
-            if (!resultTicker.Result)
-                return resultTicker.Result.AsExchangeResult<SharedFuturesTicker>(Exchange, null, default);
-            if (!resultFunding.Result)
-                return resultFunding.Result.AsExchangeResult<SharedFuturesTicker>(Exchange, null, default);
+            if (!resultTicker.Result.Success)
+                return HttpResult.Fail<SharedFuturesTicker>(resultTicker.Result);
+            if (!resultFunding.Result.Success)
+                return HttpResult.Fail<SharedFuturesTicker>(resultFunding.Result);
 
             var ticker = resultTicker.Result.Data.SingleOrDefault();
             var funding = resultFunding.Result.Data.SingleOrDefault();
 
             if (ticker == null || funding == null)
-                return resultTicker.Result.AsExchangeError<SharedFuturesTicker>(Exchange, new ServerError(new ErrorInfo(ErrorType.Unknown, "Not found")));
+                return HttpResult.Fail<SharedFuturesTicker>(resultTicker.Result, new ServerError(new ErrorInfo(ErrorType.Unknown, "Not found")));
 
-            return resultTicker.Result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, ticker.Symbol), ticker.Symbol, ticker.LastPrice, ticker.HighPrice, ticker.LowPrice, ticker.Volume, ticker.OpenPrice == 0 ? null : Math.Round(ticker.LastPrice / ticker.OpenPrice * 100 - 100, 2))
+            return HttpResult.Ok(resultTicker.Result, new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, ticker.Symbol), ticker.Symbol, ticker.LastPrice, ticker.HighPrice, ticker.LowPrice, ticker.Volume, ticker.OpenPrice == 0 ? null : Math.Round(ticker.LastPrice / ticker.OpenPrice * 100 - 100, 2))
             {
                 IndexPrice = ticker.IndexPrice,
                 MarkPrice = ticker.MarkPrice,
@@ -73,22 +74,22 @@ namespace CoinEx.Net.Clients.FuturesApi
             });
         }
 
-        GetTickersOptions IFuturesTickerRestClient.GetFuturesTickersOptions { get; } = new GetTickersOptions();
-        async Task<ExchangeWebResult<SharedFuturesTicker[]>> IFuturesTickerRestClient.GetFuturesTickersAsync(GetTickersRequest request, CancellationToken ct)
+        GetFuturesTickersOptions IFuturesTickerRestClient.GetFuturesTickersOptions { get; } = new GetFuturesTickersOptions(_exchangeName);
+        async Task<HttpResult<SharedFuturesTicker[]>> IFuturesTickerRestClient.GetFuturesTickersAsync(GetTickersRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTickerRestClient)this).GetFuturesTickersOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesTickersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesTicker[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesTicker[]>(Exchange, validationError);
 
             var resultTickers = ExchangeData.GetTickersAsync(ct: ct);
             var resultFunding = ExchangeData.GetFundingRatesAsync(ct: ct);
             await Task.WhenAll(resultTickers, resultFunding).ConfigureAwait(false);
-            if (!resultTickers.Result)
-                return resultTickers.Result.AsExchangeResult<SharedFuturesTicker[]>(Exchange, null, default);
-            if (!resultFunding.Result)
-                return resultFunding.Result.AsExchangeResult<SharedFuturesTicker[]>(Exchange, null, default);
+            if (!resultTickers.Result.Success)
+                return HttpResult.Fail<SharedFuturesTicker[]>(resultTickers.Result);
+            if (!resultFunding.Result.Success)
+                return HttpResult.Fail<SharedFuturesTicker[]>(resultFunding.Result);
 
-            return resultTickers.Result.AsExchangeResult<SharedFuturesTicker[]>(Exchange, SupportedTradingModes, resultTickers.Result.Data.Select(x =>
+            return HttpResult.Ok(resultTickers.Result, resultTickers.Result.Data.Select(x =>
             {
                 var funding = resultFunding.Result.Data.Single(p => p.Symbol == x.Symbol);
                 return new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.OpenPrice == 0 ? null : Math.Round(x.LastPrice / x.OpenPrice * 100 - 100, 2))
@@ -105,18 +106,18 @@ namespace CoinEx.Net.Clients.FuturesApi
 
         #region Book Ticker client
 
-        EndpointOptions<GetBookTickerRequest> IBookTickerRestClient.GetBookTickerOptions { get; } = new EndpointOptions<GetBookTickerRequest>(false);
-        async Task<ExchangeWebResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
+        GetBookTickerOptions IBookTickerRestClient.GetBookTickerOptions { get; } = new GetBookTickerOptions(_exchangeName, false);
+        async Task<HttpResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((IBookTickerRestClient)this).GetBookTickerOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetBookTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedBookTicker>(Exchange, validationError);
+                return HttpResult.Fail<SharedBookTicker>(Exchange, validationError);
 
             var resultTicker = await ExchangeData.GetOrderBookAsync(request.Symbol!.GetSymbol(FormatSymbol), 5, ct: ct).ConfigureAwait(false);
-            if (!resultTicker)
-                return resultTicker.AsExchangeResult<SharedBookTicker>(Exchange, null, default);
+            if (!resultTicker.Success)
+                return HttpResult.Fail<SharedBookTicker>(resultTicker);
 
-            return resultTicker.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedBookTicker(
+            return HttpResult.Ok(resultTicker, new SharedBookTicker(
                 ExchangeSymbolCache.ParseSymbol(_topicId, resultTicker.Data.Symbol),
                 resultTicker.Data.Symbol,
                 resultTicker.Data.Data.Asks[0].Price,
@@ -129,16 +130,16 @@ namespace CoinEx.Net.Clients.FuturesApi
 
         #region Futures Symbol client
 
-        EndpointOptions<GetSymbolsRequest> IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest>(false);
-        async Task<ExchangeWebResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
+        GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
+        async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesSymbolRestClient)this).GetFuturesSymbolsOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesSymbolsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesSymbol[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesSymbol[]>(Exchange, validationError);
 
             var result = await ExchangeData.GetSymbolsAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFuturesSymbol[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFuturesSymbol[]>(result);
 
             IEnumerable<CoinExFuturesSymbol> data = result.Data;
             if (request.TradingMode.HasValue)
@@ -147,9 +148,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                     request.TradingMode == TradingMode.PerpetualLinear ? x.ContractType == ContractType.Linear : x.ContractType == ContractType.Inverse);
             }
 
-            var response = result.AsExchangeResult<SharedFuturesSymbol[]>(Exchange, 
-                request.TradingMode == null ? SupportedTradingModes: new[] { request.TradingMode.Value },
-                data.Select(s => new SharedFuturesSymbol(
+            var response = HttpResult.Ok(result, data.Select(s => new SharedFuturesSymbol(
                 s.ContractType == ContractType.Inverse ? TradingMode.PerpetualInverse : TradingMode.PerpetualLinear,
                 s.BaseAsset, s.QuoteAsset, s.Symbol, s.TradingAvailable)
             {
@@ -159,22 +158,22 @@ namespace CoinEx.Net.Clients.FuturesApi
                 ContractSize = 1
             }).ToArray());
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, response.Data);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, response.Data!);
             return response;
         }
-        async Task<ExchangeResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
+        async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
         {
             if (!ExchangeSymbolCache.HasCached(_topicId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<SharedSymbol[]>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<SharedSymbol[]>(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, baseAsset));
         }
 
-        async Task<ExchangeResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
+        async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
         {
             if (symbol.TradingMode == TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Spot symbols not allowed");
@@ -182,23 +181,23 @@ namespace CoinEx.Net.Clients.FuturesApi
             if (!ExchangeSymbolCache.HasCached(_topicId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbol));
         }
 
-        async Task<ExchangeResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
+        async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
         {
             if (!ExchangeSymbolCache.HasCached(_topicId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbolName));
         }
         #endregion
 
@@ -216,19 +215,12 @@ namespace CoinEx.Net.Clients.FuturesApi
 
         string IFuturesOrderRestClient.GenerateClientOrderId() => ExchangeHelpers.RandomString(20);
 
-        PlaceFuturesOrderOptions IFuturesOrderRestClient.PlaceFuturesOrderOptions { get; } = new PlaceFuturesOrderOptions(false);
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.PlaceFuturesOrderAsync(PlaceFuturesOrderRequest request, CancellationToken ct)
+        PlaceFuturesOrderOptions IFuturesOrderRestClient.PlaceFuturesOrderOptions { get; } = new PlaceFuturesOrderOptions(_exchangeName, false);
+        async Task<HttpResult<SharedId>> IFuturesOrderRestClient.PlaceFuturesOrderAsync(PlaceFuturesOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).PlaceFuturesOrderOptions.ValidateRequest(
-                Exchange,
-                request,
-                request.Symbol!.TradingMode,
-                SupportedTradingModes,
-                ((IFuturesOrderRestClient)this).FuturesSupportedOrderTypes,
-                ((IFuturesOrderRestClient)this).FuturesSupportedTimeInForce,
-                ((IFuturesOrderRestClient)this).FuturesSupportedOrderQuantity);
+            var validationError = SharedClient.PlaceFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await Trading.PlaceOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -239,27 +231,27 @@ namespace CoinEx.Net.Clients.FuturesApi
                 clientOrderId: request.ClientOrderId,
                 ct: ct).ConfigureAwait(false);
 
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedId(result.Data.Id.ToString()));
+            return HttpResult.Ok(result, new SharedId(result.Data.Id.ToString()));
         }
 
-        EndpointOptions<GetOrderRequest> IFuturesOrderRestClient.GetFuturesOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedFuturesOrder>> IFuturesOrderRestClient.GetFuturesOrderAsync(GetOrderRequest request, CancellationToken ct)
+        GetFuturesOrderOptions IFuturesOrderRestClient.GetFuturesOrderOptions { get; } = new GetFuturesOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedFuturesOrder>> IFuturesOrderRestClient.GetFuturesOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesOrder>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedFuturesOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedFuturesOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest.OrderId), "Invalid order id"));
 
             var order = await Trading.GetOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedFuturesOrder>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedFuturesOrder>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedFuturesOrder(
+            return HttpResult.Ok(order, new SharedFuturesOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicId, order.Data.Symbol),
                 order.Data.Symbol,
                 order.Data.Id.ToString(),
@@ -279,19 +271,19 @@ namespace CoinEx.Net.Clients.FuturesApi
             });
         }
 
-        EndpointOptions<GetOpenOrdersRequest> IFuturesOrderRestClient.GetOpenFuturesOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest>(true);
-        async Task<ExchangeWebResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetOpenFuturesOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
+        GetOpenFuturesOrdersOptions IFuturesOrderRestClient.GetOpenFuturesOrdersOptions { get; } = new GetOpenFuturesOrdersOptions(_exchangeName, true);
+        async Task<HttpResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetOpenFuturesOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetOpenFuturesOrdersOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetOpenFuturesOrdersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesOrder[]>(Exchange, validationError);
 
             var symbol = request.Symbol?.GetSymbol(FormatSymbol);
             var orders = await Trading.GetOpenOrdersAsync(symbol, ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedFuturesOrder[]>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedFuturesOrder[]>(orders);
 
-            return orders.AsExchangeResult<SharedFuturesOrder[]>(Exchange, request.Symbol == null ? SupportedTradingModes : new[] { request.Symbol!.TradingMode }, orders.Data.Items.Select(x => new SharedFuturesOrder(
+            return HttpResult.Ok(orders, orders.Data.Items.Select(x => new SharedFuturesOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
                 x.Symbol,
                 x.Id.ToString(),
@@ -311,12 +303,12 @@ namespace CoinEx.Net.Clients.FuturesApi
             }).ToArray());
         }
 
-        GetClosedOrdersOptions IFuturesOrderRestClient.GetClosedFuturesOrdersOptions { get; } = new GetClosedOrdersOptions(false, true, false, 50);
-        async Task<ExchangeWebResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetClosedFuturesOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetFuturesClosedOrdersOptions IFuturesOrderRestClient.GetClosedFuturesOrdersOptions { get; } = new GetFuturesClosedOrdersOptions(_exchangeName, false, true, false, 50);
+        async Task<HttpResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetClosedFuturesOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetClosedFuturesOrdersOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetClosedFuturesOrdersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesOrder[]>(Exchange, validationError);
 
             var direction = DataDirection.Descending;
             var limit = request.Limit ?? 50;
@@ -329,8 +321,8 @@ namespace CoinEx.Net.Clients.FuturesApi
                 page: pageParams.Page,
                 pageSize: pageParams.Limit,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFuturesOrder[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFuturesOrder[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                     () => Pagination.NextPageFromPage(pageParams),
@@ -340,10 +332,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                     request.EndTime ?? DateTime.UtcNow,
                     pageParams);
 
-            return result.AsExchangeResult(
-                    Exchange,
-                    TradingMode.Spot,
-                    ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                     .Select(x => 
                         new SharedFuturesOrder(
                             ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
@@ -365,21 +354,21 @@ namespace CoinEx.Net.Clients.FuturesApi
                         }).ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<GetOrderTradesRequest> IFuturesOrderRestClient.GetFuturesOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest>(true);
-        async Task<ExchangeWebResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
+        GetFuturesOrderTradesOptions IFuturesOrderRestClient.GetFuturesOrderTradesOptions { get; } = new GetFuturesOrderTradesOptions(_exchangeName, true);
+        async Task<HttpResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesOrderTradesOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesOrderTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
 
             var orders = await Trading.GetOrderTradesAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId: orderId, ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(orders);
 
-            return orders.AsExchangeResult<SharedUserTrade[]>(Exchange, request.Symbol!.TradingMode,orders.Data.Items.Select(x => new SharedUserTrade(
+            return HttpResult.Ok(orders, orders.Data.Items.Select(x => new SharedUserTrade(
                 ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString(),
@@ -396,12 +385,12 @@ namespace CoinEx.Net.Clients.FuturesApi
             }).ToArray());
         }
 
-        GetUserTradesOptions IFuturesOrderRestClient.GetFuturesUserTradesOptions { get; } = new GetUserTradesOptions(false, true, true, 50);
-        async Task<ExchangeWebResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetFuturesUserTradesOptions IFuturesOrderRestClient.GetFuturesUserTradesOptions { get; } = new GetFuturesUserTradesOptions(_exchangeName, false, true, true, 50);
+        async Task<HttpResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesUserTradesOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesUserTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             var direction = DataDirection.Descending;
             var limit = request.Limit ?? 50;
@@ -417,8 +406,8 @@ namespace CoinEx.Net.Clients.FuturesApi
                 pageSize: pageParams.Limit,
                 ct: ct
                 ).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                     () => Pagination.NextPageFromPage(pageParams),
@@ -428,10 +417,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                     request.EndTime ?? DateTime.UtcNow,
                     pageParams);
 
-            return result.AsExchangeResult(
-                    Exchange,
-                    TradingMode.Spot,
-                    ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                     .Select(x =>
                         new SharedUserTrade(
                             ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
@@ -450,35 +436,35 @@ namespace CoinEx.Net.Clients.FuturesApi
                         }).ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<CancelOrderRequest> IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.CancelFuturesOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelFuturesOrderOptions IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new CancelFuturesOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> IFuturesOrderRestClient.CancelFuturesOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).CancelFuturesOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
 
             var order = await Trading.CancelOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedId(order.Data.Id.ToString()));
+            return HttpResult.Ok(order, new SharedId(order.Data.Id.ToString()));
         }
 
-        EndpointOptions<GetPositionsRequest> IFuturesOrderRestClient.GetPositionsOptions { get; } = new EndpointOptions<GetPositionsRequest>(true);
-        async Task<ExchangeWebResult<SharedPosition[]>> IFuturesOrderRestClient.GetPositionsAsync(GetPositionsRequest request, CancellationToken ct)
+        GetPositionsOptions IFuturesOrderRestClient.GetPositionsOptions { get; } = new GetPositionsOptions(_exchangeName, true);
+        async Task<HttpResult<SharedPosition[]>> IFuturesOrderRestClient.GetPositionsAsync(GetPositionsRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetPositionsOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetPositionsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedPosition[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedPosition[]>(Exchange, validationError);
 
             var result = await Trading.GetPositionsAsync(symbol: request.Symbol?.GetSymbol(FormatSymbol), ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedPosition[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedPosition[]>(result);
 
-            return result.AsExchangeResult<SharedPosition[]>(Exchange, request.Symbol == null ? SupportedTradingModes : new[] { request.Symbol!.TradingMode }, result.Data.Items.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.OpenInterest, x.UpdateTime)
+            return HttpResult.Ok(result, result.Data.Items.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.OpenInterest, x.UpdateTime)
             {
                 UnrealizedPnl = x.UnrealizedPnl,
                 LiquidationPrice = x.LiquidationPrice,
@@ -491,19 +477,19 @@ namespace CoinEx.Net.Clients.FuturesApi
             }).ToArray());
         }
 
-        EndpointOptions<ClosePositionRequest> IFuturesOrderRestClient.ClosePositionOptions { get; } = new EndpointOptions<ClosePositionRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.ClosePositionAsync(ClosePositionRequest request, CancellationToken ct)
+        ClosePositionOptions IFuturesOrderRestClient.ClosePositionOptions { get; } = new ClosePositionOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> IFuturesOrderRestClient.ClosePositionAsync(ClosePositionRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).ClosePositionOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.ClosePositionOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await Trading.ClosePositionAsync(symbol, OrderTypeV2.Market, ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedId(result.Data.Id.ToString()));
+            return HttpResult.Ok(result, new SharedId(result.Data.Id.ToString()));
         }
 
         private OrderSide GetOrderSide(SharedOrderSide side, SharedPositionSide? posSide)
@@ -561,31 +547,31 @@ namespace CoinEx.Net.Clients.FuturesApi
 
         #region Futures Client Id Order Client
 
-        EndpointOptions<GetOrderRequest> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedFuturesOrder>> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
+        GetFuturesOrderByClientOrderIdOptions IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdOptions { get; } = new GetFuturesOrderByClientOrderIdOptions(_exchangeName, true);
+        async Task<HttpResult<SharedFuturesOrder>> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesOrder>(Exchange, validationError);
 
             var order = await Trading.GetOpenOrdersAsync(clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedFuturesOrder>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedFuturesOrder>(order);
 
             var orderData = order.Data.Items.FirstOrDefault();
             if (orderData == null)
             {
                 order = await Trading.GetClosedOrdersAsync(clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-                if (!order)
-                    return order.AsExchangeResult<SharedFuturesOrder>(Exchange, null, default);
+                if (!order.Success)
+                return HttpResult.Fail<SharedFuturesOrder>(order);
 
                 orderData = order.Data.Items.FirstOrDefault();
             }
 
             if (orderData == null)
-                return new ExchangeWebResult<SharedFuturesOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
+                return HttpResult.Fail<SharedFuturesOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
-            return order.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedFuturesOrder(
+            return HttpResult.Ok(order, new SharedFuturesOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicId, orderData.Symbol),
                 orderData.Symbol,
                 orderData.Id.ToString(),
@@ -605,24 +591,24 @@ namespace CoinEx.Net.Clients.FuturesApi
             });
         }
 
-        EndpointOptions<CancelOrderRequest> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelFuturesOrderByClientOrderIdOptions IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdOptions { get; } = new CancelFuturesOrderByClientOrderIdOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).CancelFuturesOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var order = await Trading.CancelOrderByClientOrderIdAsync(request.Symbol!.GetSymbol(FormatSymbol), clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedId(request.OrderId));
+            return HttpResult.Ok(order, new SharedId(request.OrderId));
         }
         #endregion
 
         #region Klines client
 
-        GetKlinesOptions IKlineRestClient.GetKlinesOptions { get; } = new GetKlinesOptions(true, true, true, 1000, false,
+        GetKlinesOptions IKlineRestClient.GetKlinesOptions { get; } = new GetKlinesOptions(_exchangeName, true, true, true, 1000, false,
             SharedKlineInterval.OneMinute,
             SharedKlineInterval.FiveMinutes,
             SharedKlineInterval.FifteenMinutes,
@@ -635,15 +621,13 @@ namespace CoinEx.Net.Clients.FuturesApi
             SharedKlineInterval.OneDay,
             SharedKlineInterval.OneWeek);
 
-        async Task<ExchangeWebResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
             var interval = (Enums.KlineInterval)request.Interval;
-            if (!Enum.IsDefined(typeof(Enums.KlineInterval), interval))
-                return new ExchangeWebResult<SharedKline[]>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
-            var validationError = ((IKlineRestClient)this).GetKlinesOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetKlinesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedKline[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedKline[]>(Exchange, validationError);
 
             var direction = request.Direction ?? DataDirection.Ascending;
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
@@ -658,8 +642,8 @@ namespace CoinEx.Net.Clients.FuturesApi
                 limit: pageParams.Limit,
                 ct: ct
                 ).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedKline[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedKline[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                     () =>
@@ -675,10 +659,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                     request.EndTime ?? DateTime.UtcNow,
                     pageParams);
 
-            return result.AsExchangeResult(
-                   Exchange,
-                   TradingMode.Spot,
-                   ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
                    .Select(x =>  
                         new SharedKline(request.Symbol, symbol, x.OpenTime, x.ClosePrice, x.HighPrice, x.LowPrice, x.OpenPrice, x.Volume))
                    .ToArray(), nextPageRequest);
@@ -688,17 +669,14 @@ namespace CoinEx.Net.Clients.FuturesApi
 
         #region Mark Price Klines client
 
-        GetKlinesOptions IMarkPriceKlineRestClient.GetMarkPriceKlinesOptions { get; } = new GetKlinesOptions(true, true, true, 1000, false);
-
-        async Task<ExchangeWebResult<SharedFuturesKline[]>> IMarkPriceKlineRestClient.GetMarkPriceKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetMarkPriceKlinesOptions IMarkPriceKlineRestClient.GetMarkPriceKlinesOptions { get; } = new GetMarkPriceKlinesOptions(_exchangeName, true, true, true, 1000, false);
+        async Task<HttpResult<SharedFuturesKline[]>> IMarkPriceKlineRestClient.GetMarkPriceKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
             var interval = (Enums.KlineInterval)request.Interval;
-            if (!Enum.IsDefined(typeof(Enums.KlineInterval), interval))
-                return new ExchangeWebResult<SharedFuturesKline[]>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
-            var validationError = ((IKlineRestClient)this).GetKlinesOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetKlinesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesKline[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesKline[]>(Exchange, validationError);
 
             var direction = request.Direction ?? DataDirection.Ascending;
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
@@ -714,8 +692,8 @@ namespace CoinEx.Net.Clients.FuturesApi
                 priceType: PriceType.MarkPrice,
                 ct: ct
                 ).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFuturesKline[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFuturesKline[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                     () =>
@@ -731,10 +709,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                     request.EndTime ?? DateTime.UtcNow,
                     pageParams);
 
-            return result.AsExchangeResult(
-                   Exchange,
-                   request.Symbol.TradingMode,
-                   ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
                    .Select(x =>
                         new SharedFuturesKline(request.Symbol, symbol, x.OpenTime, x.ClosePrice, x.HighPrice, x.LowPrice, x.OpenPrice))
                    .ToArray(), nextPageRequest);
@@ -744,17 +719,14 @@ namespace CoinEx.Net.Clients.FuturesApi
 
         #region Index Price Klines client
 
-        GetKlinesOptions IIndexPriceKlineRestClient.GetIndexPriceKlinesOptions { get; } = new GetKlinesOptions(true, true, true, 1000, false);
-
-        async Task<ExchangeWebResult<SharedFuturesKline[]>> IIndexPriceKlineRestClient.GetIndexPriceKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetIndexPriceKlinesOptions IIndexPriceKlineRestClient.GetIndexPriceKlinesOptions { get; } = new GetIndexPriceKlinesOptions(_exchangeName, true, true, true, 1000, false);
+        async Task<HttpResult<SharedFuturesKline[]>> IIndexPriceKlineRestClient.GetIndexPriceKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
             var interval = (Enums.KlineInterval)request.Interval;
-            if (!Enum.IsDefined(typeof(Enums.KlineInterval), interval))
-                return new ExchangeWebResult<SharedFuturesKline[]>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
-            var validationError = ((IKlineRestClient)this).GetKlinesOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetKlinesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesKline[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesKline[]>(Exchange, validationError);
 
             var direction = request.Direction ?? DataDirection.Ascending;
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
@@ -770,8 +742,8 @@ namespace CoinEx.Net.Clients.FuturesApi
                 priceType: PriceType.IndexPrice,
                 ct: ct
                 ).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFuturesKline[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFuturesKline[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                     () =>
@@ -787,10 +759,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                     request.EndTime ?? DateTime.UtcNow,
                     pageParams);
 
-            return result.AsExchangeResult(
-                   Exchange,
-                   request.Symbol.TradingMode,
-                   ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
                    .Select(x =>
                         new SharedFuturesKline(request.Symbol, symbol, x.OpenTime, x.ClosePrice, x.HighPrice, x.LowPrice, x.OpenPrice))
                    .ToArray(), nextPageRequest);
@@ -800,22 +769,22 @@ namespace CoinEx.Net.Clients.FuturesApi
 
         #region Recent Trade client
 
-        GetRecentTradesOptions IRecentTradeRestClient.GetRecentTradesOptions { get; } = new GetRecentTradesOptions(1000, false);
-        async Task<ExchangeWebResult<SharedTrade[]>> IRecentTradeRestClient.GetRecentTradesAsync(GetRecentTradesRequest request, CancellationToken ct)
+        GetRecentTradesOptions IRecentTradeRestClient.GetRecentTradesOptions { get; } = new GetRecentTradesOptions(_exchangeName, 1000, false);
+        async Task<HttpResult<SharedTrade[]>> IRecentTradeRestClient.GetRecentTradesAsync(GetRecentTradesRequest request, CancellationToken ct)
         {
-            var validationError = ((IRecentTradeRestClient)this).GetRecentTradesOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetRecentTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedTrade[]>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.GetTradeHistoryAsync(
                 symbol,
                 limit: request.Limit,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedTrade[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedTrade[]>(result);
 
-            return result.AsExchangeResult<SharedTrade[]>(Exchange, request.Symbol!.TradingMode, result.Data.Select(x => 
+            return HttpResult.Ok(result, result.Data.Select(x => 
             new SharedTrade(request.Symbol, symbol, x.Quantity, x.Price, x.Timestamp)
             {
                 Side = x.Side == OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell
@@ -827,102 +796,102 @@ namespace CoinEx.Net.Clients.FuturesApi
         #region Leverage client
         SharedLeverageSettingMode ILeverageRestClient.LeverageSettingType => SharedLeverageSettingMode.PerSymbol;
 
-        EndpointOptions<GetLeverageRequest> ILeverageRestClient.GetLeverageOptions { get; } = new EndpointOptions<GetLeverageRequest>(true)
+        GetLeverageOptions ILeverageRestClient.GetLeverageOptions { get; } = new GetLeverageOptions(_exchangeName, true)
         {
             RequestNotes = "Leverage can only be retrieved when there is an open position, else it will return 0"
         };
-        async Task<ExchangeWebResult<SharedLeverage>> ILeverageRestClient.GetLeverageAsync(GetLeverageRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedLeverage>> ILeverageRestClient.GetLeverageAsync(GetLeverageRequest request, CancellationToken ct)
         {
-            var validationError = ((ILeverageRestClient)this).GetLeverageOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetLeverageOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedLeverage>(Exchange, validationError);
+                return HttpResult.Fail<SharedLeverage>(Exchange, validationError);
 
             var result = await Trading.GetPositionsAsync(symbol: request.Symbol!.GetSymbol(FormatSymbol), ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedLeverage>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedLeverage>(result);
 
             var sideData =  result.Data.Items.FirstOrDefault(); // Leverage can't be changed per side, so doesn't matter which we take
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedLeverage(sideData?.Leverage ?? 0)
+            return HttpResult.Ok(result, new SharedLeverage(sideData?.Leverage ?? 0)
             {
                 Side = request.PositionSide
             });
         }
 
-        SetLeverageOptions ILeverageRestClient.SetLeverageOptions { get; } = new SetLeverageOptions()
+        SetLeverageOptions ILeverageRestClient.SetLeverageOptions { get; } = new SetLeverageOptions(_exchangeName)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
                 new ParameterDescription(nameof(SetLeverageRequest.MarginMode), typeof(SharedMarginMode), "Isolated or cross margin", SharedMarginMode.Cross)
             }
         };
-        async Task<ExchangeWebResult<SharedLeverage>> ILeverageRestClient.SetLeverageAsync(SetLeverageRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedLeverage>> ILeverageRestClient.SetLeverageAsync(SetLeverageRequest request, CancellationToken ct)
         {
-            var validationError = ((ILeverageRestClient)this).SetLeverageOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SetLeverageOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedLeverage>(Exchange, validationError);
+                return HttpResult.Fail<SharedLeverage>(Exchange, validationError);
 
             var result = await Account.SetLeverageAsync(
                 symbol: request.Symbol!.GetSymbol(FormatSymbol),
                 request.MarginMode == SharedMarginMode.Isolated ? MarginMode.Isolated : MarginMode.Cross,
                 (int)request.Leverage,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedLeverage>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedLeverage>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedLeverage(result.Data.Leverage));
+            return HttpResult.Ok(result, new SharedLeverage(result.Data.Leverage));
         }
         #endregion
 
         #region Order Book client
-        GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions(new[] { 5, 10, 20, 50 }, false);
-        async Task<ExchangeWebResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
+        GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions(_exchangeName, new[] { 5, 10, 20, 50 }, false);
+        async Task<HttpResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
         {
-            var validationError = ((IOrderBookRestClient)this).GetOrderBookOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetOrderBookOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedOrderBook>(Exchange, validationError);
+                return HttpResult.Fail<SharedOrderBook>(Exchange, validationError);
 
             var result = await ExchangeData.GetOrderBookAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
                 limit: request.Limit ?? 20,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedOrderBook>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedOrderBook>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedOrderBook(result.Data.Data.Asks, result.Data.Data.Bids));
+            return HttpResult.Ok(result, new SharedOrderBook(result.Data.Data.Asks, result.Data.Data.Bids));
         }
 
         #endregion
 
         #region Open Interest client
 
-        EndpointOptions<GetOpenInterestRequest> IOpenInterestRestClient.GetOpenInterestOptions { get; } = new EndpointOptions<GetOpenInterestRequest>(true);
-        async Task<ExchangeWebResult<SharedOpenInterest>> IOpenInterestRestClient.GetOpenInterestAsync(GetOpenInterestRequest request, CancellationToken ct)
+        GetOpenInterestOptions IOpenInterestRestClient.GetOpenInterestOptions { get; } = new GetOpenInterestOptions(_exchangeName, true);
+        async Task<HttpResult<SharedOpenInterest>> IOpenInterestRestClient.GetOpenInterestAsync(GetOpenInterestRequest request, CancellationToken ct)
         {
-            var validationError = ((IOpenInterestRestClient)this).GetOpenInterestOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetOpenInterestOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedOpenInterest>(Exchange, validationError);
+                return HttpResult.Fail<SharedOpenInterest>(Exchange, validationError);
 
             var result = await ExchangeData.GetSymbolsAsync(new[] { request.Symbol!.GetSymbol(FormatSymbol) }, ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedOpenInterest>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedOpenInterest>(result);
 
             var symbol = result.Data.SingleOrDefault();
             if (symbol == null)
-                return result.AsExchangeError<SharedOpenInterest>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
+                return HttpResult.Fail<SharedOpenInterest>(result, new ServerError(new ErrorInfo(ErrorType.UnknownSymbol, "Symbol not found")));
 
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedOpenInterest(symbol.OpenInterestVolume));
+            return HttpResult.Ok(result, new SharedOpenInterest(symbol.OpenInterestVolume));
         }
 
         #endregion
 
         #region Funding Rate client
-        GetFundingRateHistoryOptions IFundingRateRestClient.GetFundingRateHistoryOptions { get; } = new GetFundingRateHistoryOptions(false, true, true, 100, false);
+        GetFundingRateHistoryOptions IFundingRateRestClient.GetFundingRateHistoryOptions { get; } = new GetFundingRateHistoryOptions(_exchangeName, false, true, true, 100, false);
 
-        async Task<ExchangeWebResult<SharedFundingRate[]>> IFundingRateRestClient.GetFundingRateHistoryAsync(GetFundingRateHistoryRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedFundingRate[]>> IFundingRateRestClient.GetFundingRateHistoryAsync(GetFundingRateHistoryRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IFundingRateRestClient)this).GetFundingRateHistoryOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFundingRateHistoryOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFundingRate[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFundingRate[]>(Exchange, validationError);
 
             var direction = request.Direction ?? DataDirection.Ascending;
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
@@ -937,8 +906,8 @@ namespace CoinEx.Net.Clients.FuturesApi
                 page: pageParams.Page,
                 pageSize: limit,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFundingRate[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFundingRate[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                     () => Pagination.NextPageFromPage(pageParams),
@@ -948,10 +917,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                     request.EndTime ?? DateTime.UtcNow,
                     pageParams);
 
-            return result.AsExchangeResult(
-                   Exchange,
-                   request.Symbol.TradingMode,
-                   ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.FundingTime!.Value, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.FundingTime!.Value, request.StartTime, request.EndTime, direction)
                    .Select(x => 
                         new SharedFundingRate(x.ActualFundingRate, x.FundingTime ?? default))
                    .ToArray(), nextPageRequest);
@@ -960,12 +926,12 @@ namespace CoinEx.Net.Clients.FuturesApi
 
         #region Position History client
 
-        GetPositionHistoryOptions IPositionHistoryRestClient.GetPositionHistoryOptions { get; } = new GetPositionHistoryOptions(false, true, true, 100);
-        async Task<ExchangeWebResult<SharedPositionHistory[]>> IPositionHistoryRestClient.GetPositionHistoryAsync(GetPositionHistoryRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetPositionHistoryOptions IPositionHistoryRestClient.GetPositionHistoryOptions { get; } = new GetPositionHistoryOptions(_exchangeName, false, true, true, 100);
+        async Task<HttpResult<SharedPositionHistory[]>> IPositionHistoryRestClient.GetPositionHistoryAsync(GetPositionHistoryRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IPositionHistoryRestClient)this).GetPositionHistoryOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetPositionHistoryOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedPositionHistory[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedPositionHistory[]>(Exchange, validationError);
 
             var direction = request.Direction ?? DataDirection.Ascending;
             var symbol = request.Symbol?.GetSymbol(FormatSymbol);
@@ -980,8 +946,8 @@ namespace CoinEx.Net.Clients.FuturesApi
                 page: pageParams.Page,
                 pageSize: limit,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedPositionHistory[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedPositionHistory[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                     () => Pagination.NextPageFromPage(pageParams),
@@ -991,10 +957,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                     request.EndTime ?? DateTime.UtcNow,
                     pageParams);
 
-            return result.AsExchangeResult(
-                   Exchange,
-                   SupportedTradingModes.Where(x => x != TradingMode.Spot).ToArray(),
-                   ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                    .Select(x => 
                         new SharedPositionHistory(
                             ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol),
@@ -1013,34 +976,34 @@ namespace CoinEx.Net.Clients.FuturesApi
         #endregion
 
         #region Fee Client
-        EndpointOptions<GetFeeRequest> IFeeRestClient.GetFeeOptions { get; } = new EndpointOptions<GetFeeRequest>(true);
+        GetFeeOptions IFeeRestClient.GetFeeOptions { get; } = new GetFeeOptions(_exchangeName, true);
 
-        async Task<ExchangeWebResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
         {
-            var validationError = ((IFeeRestClient)this).GetFeeOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFeeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFee>(Exchange, validationError);
+                return HttpResult.Fail<SharedFee>(Exchange, validationError);
 
             // Get data
             var result = await Account.GetTradingFeesAsync(request.Symbol!.GetSymbol(FormatSymbol), ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFee>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFee>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedFee(result.Data.MakerFeeRate * 100, result.Data.TakerFeeRate * 100));
+            return HttpResult.Ok(result, new SharedFee(result.Data.MakerFeeRate * 100, result.Data.TakerFeeRate * 100));
         }
         #endregion
 
         #region Futures Trigger Order Client
-        PlaceFuturesTriggerOrderOptions IFuturesTriggerOrderRestClient.PlaceFuturesTriggerOrderOptions { get; } = new PlaceFuturesTriggerOrderOptions(false)
+        PlaceFuturesTriggerOrderOptions IFuturesTriggerOrderRestClient.PlaceFuturesTriggerOrderOptions { get; } = new PlaceFuturesTriggerOrderOptions(_exchangeName, false)
         {
         };
-        async Task<ExchangeWebResult<SharedId>> IFuturesTriggerOrderRestClient.PlaceFuturesTriggerOrderAsync(PlaceFuturesTriggerOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IFuturesTriggerOrderRestClient.PlaceFuturesTriggerOrderAsync(PlaceFuturesTriggerOrderRequest request, CancellationToken ct)
         {
             var side = GetOrderSide(request);
-            var validationError = ((IFuturesTriggerOrderRestClient)this).PlaceFuturesTriggerOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes, side == OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell, ((IFuturesOrderRestClient)this).FuturesSupportedOrderQuantity);
+            var validationError = SharedClient.PlaceFuturesTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var clientOrderId = request.ClientOrderId ?? ExchangeHelpers.RandomString(32);
             var result = await Trading.PlaceStopOrderAsync(
@@ -1053,27 +1016,27 @@ namespace CoinEx.Net.Clients.FuturesApi
                 triggerPriceType: GetTriggerPriceType(request),
                 clientOrderId: clientOrderId,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedId(clientOrderId));
+            return HttpResult.Ok(result, new SharedId(clientOrderId));
         }
 
-        EndpointOptions<GetOrderRequest> IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true)
+        GetFuturesTriggerOrderOptions IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderOptions { get; } = new GetFuturesTriggerOrderOptions(_exchangeName, true)
         {
             RequestNotes = "Only pending trigger orders can be requested, executed trigger orders are not available in the API"
         };
-        async Task<ExchangeWebResult<SharedFuturesTriggerOrder>> IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedFuturesTriggerOrder>> IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTriggerOrderRestClient)this).GetFuturesTriggerOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesTriggerOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesTriggerOrder>(Exchange, validationError);
 
             var status = SharedTriggerOrderStatus.Active;
             var orders = await Trading.GetOpenStopOrdersAsync(clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedFuturesTriggerOrder>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedFuturesTriggerOrder>(orders);
 
             CoinExStopOrder order;
             if (orders.Data.Items.Any())
@@ -1083,17 +1046,17 @@ namespace CoinEx.Net.Clients.FuturesApi
             else
             {
                 orders = await Trading.GetClosedStopOrdersAsync(request.Symbol!.GetSymbol(FormatSymbol), pageSize: 1000, ct: ct).ConfigureAwait(false);
-                if (!orders)
-                    return orders.AsExchangeResult<SharedFuturesTriggerOrder>(Exchange, null, default);
+                if (!orders.Success)
+                return HttpResult.Fail<SharedFuturesTriggerOrder>(orders);
 
                 order = orders.Data.Items.SingleOrDefault(x => x.ClientOrderId == request.OrderId)!;
                 if (order == null)
-                    return orders.AsExchangeError<SharedFuturesTriggerOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
+                    return HttpResult.Fail<SharedFuturesTriggerOrder>(orders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
                 status = SharedTriggerOrderStatus.Filled;
             }
 
-            return orders.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedFuturesTriggerOrder(
+            return HttpResult.Ok(orders, new SharedFuturesTriggerOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicId, order.Symbol),
                 order.Symbol,
                 order.ClientOrderId?.ToString() ?? order.StopOrderId.ToString(),
@@ -1111,21 +1074,21 @@ namespace CoinEx.Net.Clients.FuturesApi
             });
         }
 
-        EndpointOptions<CancelOrderRequest> IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelFuturesTriggerOrderOptions IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderOptions { get; } = new CancelFuturesTriggerOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTriggerOrderRestClient)this).CancelFuturesTriggerOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelFuturesTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var order = await Trading.CancelStopOrderByClientOrderIdAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
                 request.OrderId,
                 ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedId(request.OrderId));
+            return HttpResult.Ok(order, new SharedId(request.OrderId));
         }
 
         private TriggerPriceType GetTriggerPriceType(PlaceFuturesTriggerOrderRequest request)
@@ -1149,7 +1112,7 @@ namespace CoinEx.Net.Clients.FuturesApi
         #endregion
 
         #region Tp/SL Client
-        EndpointOptions<SetTpSlRequest> IFuturesTpSlRestClient.SetFuturesTpSlOptions { get; } = new EndpointOptions<SetTpSlRequest>(true)
+        SetFuturesTpSlOptions IFuturesTpSlRestClient.SetFuturesTpSlOptions { get; } = new SetFuturesTpSlOptions(_exchangeName, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -1157,13 +1120,13 @@ namespace CoinEx.Net.Clients.FuturesApi
             }
         };
 
-        async Task<ExchangeWebResult<SharedId>> IFuturesTpSlRestClient.SetFuturesTpSlAsync(SetTpSlRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IFuturesTpSlRestClient.SetFuturesTpSlAsync(SetTpSlRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTpSlRestClient)this).SetFuturesTpSlOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SetFuturesTpSlOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
-            WebCallResult<CoinExPosition> result;
+            HttpResult<CoinExPosition> result;
             if (request.TpSlSide == SharedTpSlSide.TakeProfit)
             {
                 result = await Trading.SetTakeProfitAsync(
@@ -1181,14 +1144,14 @@ namespace CoinEx.Net.Clients.FuturesApi
                                 ct: ct).ConfigureAwait(false);
             }
 
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedId(""));
+            return HttpResult.Ok(result, new SharedId(""));
         }
 
-        EndpointOptions<CancelTpSlRequest> IFuturesTpSlRestClient.CancelFuturesTpSlOptions { get; } = new EndpointOptions<CancelTpSlRequest>(true)
+        CancelFuturesTpSlOptions IFuturesTpSlRestClient.CancelFuturesTpSlOptions { get; } = new CancelFuturesTpSlOptions(_exchangeName, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -1196,13 +1159,13 @@ namespace CoinEx.Net.Clients.FuturesApi
             }
         };
 
-        async Task<ExchangeWebResult<bool>> IFuturesTpSlRestClient.CancelFuturesTpSlAsync(CancelTpSlRequest request, CancellationToken ct)
+        async Task<HttpResult<bool>> IFuturesTpSlRestClient.CancelFuturesTpSlAsync(CancelTpSlRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTpSlRestClient)this).CancelFuturesTpSlOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelFuturesTpSlOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<bool>(Exchange, validationError);
+                return HttpResult.Fail<bool>(Exchange, validationError);
 
-            WebCallResult<CoinExPosition> result;
+            HttpResult<CoinExPosition> result;
             if (request.TpSlSide == SharedTpSlSide.TakeProfit)
             {
                 result = await Trading.SetTakeProfitAsync(
@@ -1219,11 +1182,11 @@ namespace CoinEx.Net.Clients.FuturesApi
                                 0,
                                 ct: ct).ConfigureAwait(false);
             }
-            if (!result)
-                return result.AsExchangeResult<bool>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<bool>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, true);
+            return HttpResult.Ok(result, true);
         }
 
         #endregion

--- a/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiTrading.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiTrading.cs
@@ -25,7 +25,7 @@ namespace CoinEx.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExFuturesOrder>> PlaceOrderAsync(
+        public async Task<HttpResult<CoinExFuturesOrder>> PlaceOrderAsync(
             string symbol,
             OrderSide side,
             OrderTypeV2 type,
@@ -42,24 +42,24 @@ namespace CoinEx.Net.Clients.FuturesApi
                 32,
                 _baseClient.ClientOptions.AllowAppendingClientOrderId);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddEnum("side", side);
-            parameters.AddEnum("type", type);
-            parameters.AddString("amount", quantity);
-            parameters.AddOptionalString("price", price);
-            parameters.AddOptional("client_id", clientOrderId);
-            parameters.AddOptional("is_hide", hide);
-            parameters.AddOptionalEnum("stp_mode", stpMode);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/order", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("side", side);
+            parameters.Add("type", type);
+            parameters.Add("amount", quantity);
+            parameters.Add("price", price);
+            parameters.Add("client_id", clientOrderId);
+            parameters.Add("is_hide", hide);
+            parameters.Add("stp_mode", stpMode);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/order", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
             return await _baseClient.SendAsync<CoinExFuturesOrder>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExStopId>> PlaceStopOrderAsync(
+        public async Task<HttpResult<CoinExStopId>> PlaceStopOrderAsync(
             string symbol,
             OrderSide side,
             OrderTypeV2 type,
@@ -78,26 +78,26 @@ namespace CoinEx.Net.Clients.FuturesApi
                 32,
                 _baseClient.ClientOptions.AllowAppendingClientOrderId);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddEnum("side", side);
-            parameters.AddEnum("type", type);
-            parameters.AddEnum("trigger_price_type", triggerPriceType);
-            parameters.AddString("amount", quantity);
-            parameters.AddString("trigger_price", triggerPrice);
-            parameters.AddOptionalString("price", price);
-            parameters.AddOptional("client_id", clientOrderId);
-            parameters.AddOptional("is_hide", hide);
-            parameters.AddOptionalEnum("stp_mode", stpMode);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/stop-order", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("side", side);
+            parameters.Add("type", type);
+            parameters.Add("trigger_price_type", triggerPriceType);
+            parameters.Add("amount", quantity);
+            parameters.Add("trigger_price", triggerPrice);
+            parameters.Add("price", price);
+            parameters.Add("client_id", clientOrderId);
+            parameters.Add("is_hide", hide);
+            parameters.Add("stp_mode", stpMode);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/stop-order", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
             return await _baseClient.SendAsync<CoinExStopId>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CallResult<CoinExFuturesOrder>[]>> PlaceMultipleOrdersAsync(
+        public async Task<HttpResult<CallResult<CoinExFuturesOrder>[]>> PlaceMultipleOrdersAsync(
             IEnumerable<CoinExFuturesPlaceOrderRequest> requests,
             CancellationToken ct = default)
         {
@@ -110,32 +110,32 @@ namespace CoinEx.Net.Clients.FuturesApi
                     _baseClient.ClientOptions.AllowAppendingClientOrderId);
             }
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "orders", requests.ToArray() }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/batch-order", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/batch-order", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
             var resultData = await _baseClient.SendAsync<CoinExBatchResult<CoinExFuturesOrder>[]>(request, parameters, ct, weight: requests.Count()).ConfigureAwait(false);
-            if (!resultData)
-                return resultData.As<CallResult<CoinExFuturesOrder>[]>(default);
+            if (!resultData.Success)
+                return HttpResult.Fail<CallResult<CoinExFuturesOrder>[]>(resultData);
 
             var result = new List<CallResult<CoinExFuturesOrder>>();
             foreach (var item in resultData.Data!)
             {
                 if (item.Code != 0)
-                    result.Add(new CallResult<CoinExFuturesOrder>(new ServerError(item.Code, _baseClient.GetErrorInfo(item.Code, item.Message!))));
+                    result.Add(CallResult<CoinExFuturesOrder>.Fail(new ServerError(item.Code, _baseClient.GetErrorInfo(item.Code, item.Message!))));
                 else
-                    result.Add(new CallResult<CoinExFuturesOrder>(item.Data!));
+                    result.Add(CallResult<CoinExFuturesOrder>.Ok(item.Data!));
             }
 
             if (result.All(x => !x.Success))
-                return resultData.AsErrorWithData(new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), result.ToArray());
+                return HttpResult.Fail<CallResult<CoinExFuturesOrder>[]>(resultData, new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), result.ToArray());
 
-            return resultData.As(result.ToArray());
+            return HttpResult.Ok(resultData, result.ToArray());
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CallResult<CoinExStopId>[]>> PlaceMultipleStopOrdersAsync(
+        public async Task<HttpResult<CallResult<CoinExStopId>[]>> PlaceMultipleStopOrdersAsync(
             IEnumerable<CoinExFuturesPlaceStopOrderRequest> requests,
             CancellationToken ct = default)
         {
@@ -148,44 +148,44 @@ namespace CoinEx.Net.Clients.FuturesApi
                     _baseClient.ClientOptions.AllowAppendingClientOrderId);
             }
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "orders", requests.ToArray() }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/batch-stop-order", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/batch-stop-order", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
             var resultData = await _baseClient.SendAsync<CoinExBatchResult<CoinExStopId>[]>(request, parameters, ct, weight: requests.Count()).ConfigureAwait(false);
-            if (!resultData)
-                return resultData.As<CallResult<CoinExStopId>[]>(default);
+            if (!resultData.Success)
+                return HttpResult.Fail<CallResult<CoinExStopId>[]>(resultData);
 
             var result = new List<CallResult<CoinExStopId>>();
             foreach (var item in resultData.Data!)
             {
                 if (item.Code != 0)
-                    result.Add(new CallResult<CoinExStopId>(new ServerError(item.Code, _baseClient.GetErrorInfo(item.Code, item.Message!))));
+                    result.Add(CallResult<CoinExStopId>.Fail(new ServerError(item.Code, _baseClient.GetErrorInfo(item.Code, item.Message!))));
                 else
-                    result.Add(new CallResult<CoinExStopId>(item.Data!));
+                    result.Add(CallResult<CoinExStopId>.Ok(item.Data!));
             }
 
             if (result.All(x => !x.Success))
-                return resultData.AsErrorWithData(new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), result.ToArray());
+                return HttpResult.Fail(resultData, new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), result.ToArray());
 
-            return resultData.As(result.ToArray());
+            return HttpResult.Ok(resultData, result.ToArray());
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExFuturesOrder>> GetOrderAsync(string symbol, long orderId, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExFuturesOrder>> GetOrderAsync(string symbol, long orderId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "order_id", orderId }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/order-status", CoinExExchange.RateLimiter.CoinExRestFuturesQuery, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/order-status", CoinExExchange.RateLimiter.CoinExRestFuturesQuery, 1, true);
             return await _baseClient.SendAsync<CoinExFuturesOrder>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExFuturesOrder>>> GetOpenOrdersAsync(string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExFuturesOrder>>> GetOpenOrdersAsync(string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
             if (clientOrderId != null)
             {
@@ -196,19 +196,19 @@ namespace CoinEx.Net.Clients.FuturesApi
                     _baseClient.ClientOptions.AllowAppendingClientOrderId);
             }
 
-            var parameters = new ParameterCollection();
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddOptionalEnum("side", side);
-            parameters.AddOptional("market", symbol);
-            parameters.AddOptional("client_id", clientOrderId);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/pending-order", CoinExExchange.RateLimiter.CoinExRestFuturesQuery, 1, true);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("side", side);
+            parameters.Add("market", symbol);
+            parameters.Add("client_id", clientOrderId);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/pending-order", CoinExExchange.RateLimiter.CoinExRestFuturesQuery, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExFuturesOrder>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExFuturesOrder>>> GetClosedOrdersAsync(string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExFuturesOrder>>> GetClosedOrdersAsync(string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
             if (clientOrderId != null)
             {
@@ -219,19 +219,19 @@ namespace CoinEx.Net.Clients.FuturesApi
                     _baseClient.ClientOptions.AllowAppendingClientOrderId);
             }
 
-            var parameters = new ParameterCollection();
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddOptionalEnum("side", side);
-            parameters.AddOptional("market", symbol);
-            parameters.AddOptional("client_id", clientOrderId);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/finished-order", CoinExExchange.RateLimiter.CoinExRestFuturesHistory, 1, true);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("side", side);
+            parameters.Add("market", symbol);
+            parameters.Add("client_id", clientOrderId);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/finished-order", CoinExExchange.RateLimiter.CoinExRestFuturesHistory, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExFuturesOrder>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExStopOrder>>> GetOpenStopOrdersAsync(string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExStopOrder>>> GetOpenStopOrdersAsync(string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
             if (clientOrderId != null)
             {
@@ -242,52 +242,52 @@ namespace CoinEx.Net.Clients.FuturesApi
                     _baseClient.ClientOptions.AllowAppendingClientOrderId);
             }
 
-            var parameters = new ParameterCollection();
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddOptionalEnum("side", side);
-            parameters.AddOptional("market", symbol);
-            parameters.AddOptional("client_id", clientOrderId);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/pending-stop-order", CoinExExchange.RateLimiter.CoinExRestFuturesQuery, 1, true);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("side", side);
+            parameters.Add("market", symbol);
+            parameters.Add("client_id", clientOrderId);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/pending-stop-order", CoinExExchange.RateLimiter.CoinExRestFuturesQuery, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExStopOrder>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExStopOrder>>> GetClosedStopOrdersAsync(string? symbol = null, OrderSide? side = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExStopOrder>>> GetClosedStopOrdersAsync(string? symbol = null, OrderSide? side = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddOptionalEnum("side", side);
-            parameters.AddOptional("market", symbol);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/finished-stop-order", CoinExExchange.RateLimiter.CoinExRestFuturesHistory, 1, true);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("side", side);
+            parameters.Add("market", symbol);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/finished-stop-order", CoinExExchange.RateLimiter.CoinExRestFuturesHistory, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExStopOrder>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExFuturesOrder>> EditOrderAsync(
+        public async Task<HttpResult<CoinExFuturesOrder>> EditOrderAsync(
             string symbol,
             long orderId,
             decimal quantity,
             decimal? price = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "order_id", orderId }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddString("amount", quantity);
-            parameters.AddOptionalString("price", price);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/modify-order", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("amount", quantity);
+            parameters.Add("price", price);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/modify-order", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
             return await _baseClient.SendAsync<CoinExFuturesOrder>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExStopId>> EditStopOrderAsync(
+        public async Task<HttpResult<CoinExStopId>> EditStopOrderAsync(
             string symbol,
             long stopOrderId,
             decimal quantity,
@@ -295,62 +295,62 @@ namespace CoinEx.Net.Clients.FuturesApi
             decimal? price = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "stop_id", stopOrderId }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddString("amount", quantity);
-            parameters.AddString("trigger_price", triggerPrice);
-            parameters.AddOptionalString("price", price);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/modify-stop-order", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("amount", quantity);
+            parameters.Add("trigger_price", triggerPrice);
+            parameters.Add("price", price);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/modify-stop-order", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
             return await _baseClient.SendAsync<CoinExStopId>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult> CancelAllOrdersAsync(string symbol, OrderSide? side = null, CancellationToken ct = default)
+        public async Task<HttpResult> CancelAllOrdersAsync(string symbol, OrderSide? side = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddOptionalEnum("side", side);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/cancel-all-order", CoinExExchange.RateLimiter.CoinExRestFuturesBatchCancel, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("side", side);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/cancel-all-order", CoinExExchange.RateLimiter.CoinExRestFuturesBatchCancel, 1, true);
             return await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExFuturesOrder>> CancelOrderAsync(string symbol, long orderId, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExFuturesOrder>> CancelOrderAsync(string symbol, long orderId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "order_id", orderId }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/cancel-order", CoinExExchange.RateLimiter.CoinExRestFuturesCancel, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/cancel-order", CoinExExchange.RateLimiter.CoinExRestFuturesCancel, 1, true);
             return await _baseClient.SendAsync<CoinExFuturesOrder>(request, parameters, ct).ConfigureAwait(false);
             
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExStopOrder>> CancelStopOrderAsync(string symbol, long stopOrderId, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExStopOrder>> CancelStopOrderAsync(string symbol, long stopOrderId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "stop_id", stopOrderId }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/cancel-stop-order", CoinExExchange.RateLimiter.CoinExRestFuturesCancel, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/cancel-stop-order", CoinExExchange.RateLimiter.CoinExRestFuturesCancel, 1, true);
             return await _baseClient.SendAsync<CoinExStopOrder>(request, parameters, ct).ConfigureAwait(false);
             
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExBatchResult<CoinExFuturesOrder>[]>> CancelOrderByClientOrderIdAsync(string symbol, string clientOrderId, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExBatchResult<CoinExFuturesOrder>[]>> CancelOrderByClientOrderIdAsync(string symbol, string clientOrderId, CancellationToken ct = default)
         {
             clientOrderId = LibraryHelpers.ApplyBrokerId(
                 clientOrderId,
@@ -358,19 +358,19 @@ namespace CoinEx.Net.Clients.FuturesApi
                 32,
                 _baseClient.ClientOptions.AllowAppendingClientOrderId);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "client_id", clientOrderId }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/cancel-order-by-client-id", CoinExExchange.RateLimiter.CoinExRestFuturesBatchCancel, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/cancel-order-by-client-id", CoinExExchange.RateLimiter.CoinExRestFuturesBatchCancel, 1, true);
             return await _baseClient.SendAsync<CoinExBatchResult<CoinExFuturesOrder>[]>(request, parameters, ct).ConfigureAwait(false);
             
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExBatchResult<CoinExStopOrder>[]>> CancelStopOrderByClientOrderIdAsync(string symbol, string clientStopOrderId, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExBatchResult<CoinExStopOrder>[]>> CancelStopOrderByClientOrderIdAsync(string symbol, string clientStopOrderId, CancellationToken ct = default)
         {
             clientStopOrderId = LibraryHelpers.ApplyBrokerId(
                 clientStopOrderId,
@@ -378,103 +378,103 @@ namespace CoinEx.Net.Clients.FuturesApi
                 32,
                 _baseClient.ClientOptions.AllowAppendingClientOrderId);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "client_id", clientStopOrderId }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/cancel-stop-order-by-client-id", CoinExExchange.RateLimiter.CoinExRestFuturesBatchCancel, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/cancel-stop-order-by-client-id", CoinExExchange.RateLimiter.CoinExRestFuturesBatchCancel, 1, true);
             return await _baseClient.SendAsync<CoinExBatchResult<CoinExStopOrder>[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExBatchResult<CoinExFuturesOrder>[]>> CancelOrdersAsync(string symbol, IEnumerable<long> orderIds, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExBatchResult<CoinExFuturesOrder>[]>> CancelOrdersAsync(string symbol, IEnumerable<long> orderIds, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "order_ids", orderIds.ToArray() }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/cancel-batch-order", CoinExExchange.RateLimiter.CoinExRestFuturesBatchCancel, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/cancel-batch-order", CoinExExchange.RateLimiter.CoinExRestFuturesBatchCancel, 1, true);
             return await _baseClient.SendAsync<CoinExBatchResult<CoinExFuturesOrder>[]>(request, parameters, ct, weight: orderIds.Count()).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExBatchResult<CoinExStopOrder>[]>> CancelStopOrdersAsync(string symbol, IEnumerable<long> orderIds, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExBatchResult<CoinExStopOrder>[]>> CancelStopOrdersAsync(string symbol, IEnumerable<long> orderIds, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "stop_ids", orderIds.ToArray() }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/cancel-batch-stop-order", CoinExExchange.RateLimiter.CoinExRestFuturesBatchCancel, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/cancel-batch-stop-order", CoinExExchange.RateLimiter.CoinExRestFuturesBatchCancel, 1, true);
             return await _baseClient.SendAsync<CoinExBatchResult<CoinExStopOrder>[]>(request, parameters, ct, weight: orderIds.Count()).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExUserTrade>>> GetUserTradesAsync(string symbol, OrderSide? side = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExUserTrade>>> GetUserTradesAsync(string symbol, OrderSide? side = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddOptionalEnum("side", side);
-            parameters.AddOptionalMilliseconds("start_time", startTime);
-            parameters.AddOptionalMilliseconds("end_Time", endTime);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/user-deals", CoinExExchange.RateLimiter.CoinExRestFuturesHistory, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("side", side);
+            parameters.Add("start_time", startTime);
+            parameters.Add("end_Time", endTime);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/user-deals", CoinExExchange.RateLimiter.CoinExRestFuturesHistory, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExUserTrade>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExUserTrade>>> GetOrderTradesAsync(string symbol, long orderId, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExUserTrade>>> GetOrderTradesAsync(string symbol, long orderId, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "order_id", orderId }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/order-deals", CoinExExchange.RateLimiter.CoinExRestFuturesHistory, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/order-deals", CoinExExchange.RateLimiter.CoinExRestFuturesHistory, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExUserTrade>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExPosition>>> GetPositionsAsync(string? symbol = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExPosition>>> GetPositionsAsync(string? symbol = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbol);
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/pending-position", CoinExExchange.RateLimiter.CoinExRestFuturesQuery, 1, true);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market", symbol);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/pending-position", CoinExExchange.RateLimiter.CoinExRestFuturesQuery, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExPosition>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExPosition>>> GetPositionHistoryAsync(string? symbol = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExPosition>>> GetPositionHistoryAsync(string? symbol = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbol);
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddOptionalMilliseconds("start_time", startTime);
-            parameters.AddOptionalMilliseconds("end_time", endTime);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/finished-position", CoinExExchange.RateLimiter.CoinExRestFuturesHistory, 1, true);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market", symbol);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("start_time", startTime);
+            parameters.Add("end_time", endTime);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/finished-position", CoinExExchange.RateLimiter.CoinExRestFuturesHistory, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExPosition>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExFuturesOrder>> ClosePositionAsync(string symbol, OrderTypeV2 orderType, decimal? price = null, decimal? quantity = null, string? clientOrderId = null, bool? hidden = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExFuturesOrder>> ClosePositionAsync(string symbol, OrderTypeV2 orderType, decimal? price = null, decimal? quantity = null, string? clientOrderId = null, bool? hidden = null, CancellationToken ct = default)
         {
             clientOrderId = LibraryHelpers.ApplyBrokerId(
                 clientOrderId,
@@ -482,186 +482,186 @@ namespace CoinEx.Net.Clients.FuturesApi
                 32,
                 _baseClient.ClientOptions.AllowAppendingClientOrderId);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddEnum("type", orderType);
-            parameters.AddOptionalString("price", price);
-            parameters.AddOptionalString("amount", quantity);
-            parameters.AddOptional("client_id", clientOrderId);
-            parameters.AddOptional("is_hide", hidden);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/close-position", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("type", orderType);
+            parameters.Add("price", price);
+            parameters.Add("amount", quantity);
+            parameters.Add("client_id", clientOrderId);
+            parameters.Add("is_hide", hidden);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/close-position", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
             return await _baseClient.SendAsync<CoinExFuturesOrder>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPosition>> AdjustPositionMarginAsync(string symbol, decimal quantity, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPosition>> AdjustPositionMarginAsync(string symbol, decimal quantity, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddString("amount", quantity);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/adjust-position-margin", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("amount", quantity);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/adjust-position-margin", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
             return await _baseClient.SendAsync<CoinExPosition>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPosition>> SetStopLossAsync(string symbol, PriceType stopLossType, decimal stopLossPrice, decimal? stopLossQuantity = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPosition>> SetStopLossAsync(string symbol, PriceType stopLossType, decimal stopLossPrice, decimal? stopLossQuantity = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddEnum("stop_loss_type", stopLossType);
-            parameters.AddString("stop_loss_price", stopLossPrice);
-            parameters.AddOptionalString("stop_loss_amount", stopLossQuantity);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/set-position-stop-loss", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("stop_loss_type", stopLossType);
+            parameters.Add("stop_loss_price", stopLossPrice);
+            parameters.Add("stop_loss_amount", stopLossQuantity);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/set-position-stop-loss", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
             return await _baseClient.SendAsync<CoinExPosition>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPosition>> EditStopLossAsync(string symbol, long stopLossOrderId, PriceType? stopLossType = null, decimal? stopLossPrice = null, decimal? stopLossQuantity = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPosition>> EditStopLossAsync(string symbol, long stopLossOrderId, PriceType? stopLossType = null, decimal? stopLossPrice = null, decimal? stopLossQuantity = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "stop_loss_id", stopLossOrderId }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddOptionalEnum("stop_loss_type", stopLossType);
-            parameters.AddOptionalString("stop_loss_price", stopLossPrice);
-            parameters.AddOptionalString("stop_loss_amount", stopLossQuantity);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/modify-position-stop-loss", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("stop_loss_type", stopLossType);
+            parameters.Add("stop_loss_price", stopLossPrice);
+            parameters.Add("stop_loss_amount", stopLossQuantity);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/modify-position-stop-loss", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
             return await _baseClient.SendAsync<CoinExPosition>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPosition>> CancelStopLossAsync(string symbol, long? stopLossOrderId = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPosition>> CancelStopLossAsync(string symbol, long? stopLossOrderId = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
             };
-            parameters.AddOptional("stop_loss_id", stopLossOrderId);
-            parameters.AddEnum("market_type", AccountType.Futures);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/cancel-position-stop-loss", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
+            parameters.Add("stop_loss_id", stopLossOrderId);
+            parameters.Add("market_type", AccountType.Futures);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/cancel-position-stop-loss", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
             return await _baseClient.SendAsync<CoinExPosition>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPosition>> SetTakeProfitAsync(string symbol, PriceType takeProfitType, decimal takeProfitPrice, decimal? takeProfitQuantity = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPosition>> SetTakeProfitAsync(string symbol, PriceType takeProfitType, decimal takeProfitPrice, decimal? takeProfitQuantity = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddEnum("take_profit_type", takeProfitType);
-            parameters.AddString("take_profit_price", takeProfitPrice);
-            parameters.AddOptionalString("take_profit_amount", takeProfitQuantity);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/set-position-take-profit", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("take_profit_type", takeProfitType);
+            parameters.Add("take_profit_price", takeProfitPrice);
+            parameters.Add("take_profit_amount", takeProfitQuantity);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/set-position-take-profit", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
             return await _baseClient.SendAsync<CoinExPosition>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPosition>> EditTakeProfitAsync(string symbol, long takeProfitOrderId, PriceType? takeProfitType = null, decimal? takeProfitPrice = null, decimal? takeProfitQuantity = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPosition>> EditTakeProfitAsync(string symbol, long takeProfitOrderId, PriceType? takeProfitType = null, decimal? takeProfitPrice = null, decimal? takeProfitQuantity = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "take_profit_id", takeProfitOrderId }
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddOptionalEnum("take_profit_type", takeProfitType);
-            parameters.AddOptionalString("take_profit_price", takeProfitPrice);
-            parameters.AddOptionalString("take_profit_amount", takeProfitQuantity);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/modify-position-take-profit", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("take_profit_type", takeProfitType);
+            parameters.Add("take_profit_price", takeProfitPrice);
+            parameters.Add("take_profit_amount", takeProfitQuantity);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/modify-position-take-profit", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
             return await _baseClient.SendAsync<CoinExPosition>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPosition>> CancelTakeProfitAsync(string symbol, long? takeProfitOrderId = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPosition>> CancelTakeProfitAsync(string symbol, long? takeProfitOrderId = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
             };
-            parameters.AddOptional("take_profit_id", takeProfitOrderId);
-            parameters.AddEnum("market_type", AccountType.Futures);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/futures/cancel-position-take-profit", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
+            parameters.Add("take_profit_id", takeProfitOrderId);
+            parameters.Add("market_type", AccountType.Futures);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/futures/cancel-position-take-profit", CoinExExchange.RateLimiter.CoinExRestFuturesOrder, 1, true);
             return await _baseClient.SendAsync<CoinExPosition>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExPositionMargin>>> GetMarginHistoryAsync(string symbol, long positionId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExPositionMargin>>> GetMarginHistoryAsync(string symbol, long positionId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "position_id", positionId },
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddOptionalMilliseconds("start_time", startTime);
-            parameters.AddOptionalMilliseconds("end_time", endTime);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/position-margin-history", CoinExExchange.RateLimiter.CoinExRestFuturesQuery, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("start_time", startTime);
+            parameters.Add("end_time", endTime);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/position-margin-history", CoinExExchange.RateLimiter.CoinExRestFuturesQuery, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExPositionMargin>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExPositionFundingRate>>> GetFundingRateHistoryAsync(string symbol, long positionId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExPositionFundingRate>>> GetFundingRateHistoryAsync(string symbol, long positionId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "position_id", positionId },
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddOptionalMilliseconds("start_time", startTime);
-            parameters.AddOptionalMilliseconds("end_time", endTime);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/position-funding-history", CoinExExchange.RateLimiter.CoinExRestFuturesQuery, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("start_time", startTime);
+            parameters.Add("end_time", endTime);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/position-funding-history", CoinExExchange.RateLimiter.CoinExRestFuturesQuery, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExPositionFundingRate>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExPositionAdl>>> GetAutoDeleverageHistoryAsync(string symbol, long positionId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExPositionAdl>>> GetAutoDeleverageHistoryAsync(string symbol, long positionId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "position_id", positionId },
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddOptionalMilliseconds("start_time", startTime);
-            parameters.AddOptionalMilliseconds("end_time", endTime);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/position-adl-history", CoinExExchange.RateLimiter.CoinExRestFuturesQuery, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("start_time", startTime);
+            parameters.Add("end_time", endTime);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/position-adl-history", CoinExExchange.RateLimiter.CoinExRestFuturesQuery, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExPositionAdl>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExPositionSettlement>>> GetAutoSettlementHistoryAsync(string symbol, long positionId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExPositionSettlement>>> GetAutoSettlementHistoryAsync(string symbol, long positionId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "position_id", positionId },
             };
-            parameters.AddEnum("market_type", AccountType.Futures);
-            parameters.AddOptionalMilliseconds("start_time", startTime);
-            parameters.AddOptionalMilliseconds("end_time", endTime);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/futures/position-settle-history", CoinExExchange.RateLimiter.CoinExRestFuturesQuery, 1, true);
+            parameters.Add("market_type", AccountType.Futures);
+            parameters.Add("start_time", startTime);
+            parameters.Add("end_time", endTime);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/futures/position-settle-history", CoinExExchange.RateLimiter.CoinExRestFuturesQuery, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExPositionSettlement>(request, parameters, ct).ConfigureAwait(false);
         }
     }

--- a/CoinEx.Net/Clients/FuturesApi/CoinExSocketClientFuturesApi.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExSocketClientFuturesApi.cs
@@ -43,7 +43,7 @@ namespace CoinEx.Net.Clients.FuturesApi
         /// Create a new instance of CoinExSocketClient with default options
         /// </summary>
         internal CoinExSocketClientFuturesApi(ILogger logger, CoinExSocketOptions options)
-            : base(logger, options.Environment.SocketBaseAddress, options, options.FuturesOptions)
+            : base(logger, CoinExExchange.Metadata.Id, options.Environment.SocketBaseAddress, options, options.FuturesOptions)
         {
             KeepAliveInterval = TimeSpan.Zero; // Server doesn't correctly respond to ping frames
 
@@ -92,7 +92,7 @@ namespace CoinEx.Net.Clients.FuturesApi
         #region public
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExFuturesTickerUpdate[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExFuturesTickerUpdate[]>> onMessage, CancellationToken ct = default)
         {
             var subscription = new CoinExFuturesTickerSubscription(_logger, this, symbols.ToArray(), new Dictionary<string, object>
             {
@@ -102,7 +102,7 @@ namespace CoinEx.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(Action<DataEvent<CoinExFuturesTickerUpdate[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(Action<DataEvent<CoinExFuturesTickerUpdate[]>> onMessage, CancellationToken ct = default)
         {
             var subscription = new CoinExFuturesTickerSubscription(_logger, this, [], new Dictionary<string, object>
             {
@@ -112,11 +112,11 @@ namespace CoinEx.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int depth, string? mergeLevel, bool fullBookUpdates, Action<DataEvent<CoinExOrderBook>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int depth, string? mergeLevel, bool fullBookUpdates, Action<DataEvent<CoinExOrderBook>> onMessage, CancellationToken ct = default)
             => SubscribeToOrderBookUpdatesAsync(new[] { symbol }, depth, mergeLevel, fullBookUpdates, onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, int depth, string? mergeLevel, bool fullBookUpdates, Action<DataEvent<CoinExOrderBook>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, int depth, string? mergeLevel, bool fullBookUpdates, Action<DataEvent<CoinExOrderBook>> onMessage, CancellationToken ct = default)
         {
             var subscription = new CoinExFuturesOrderBookSubscription(_logger, this, symbols.ToArray(), new Dictionary<string, object>
             {
@@ -126,15 +126,15 @@ namespace CoinEx.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default)
             => SubscribeToTradeUpdatesAsync(new[] { symbol }, onMessage, ct);
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default)
             => SubscribeToTradeUpdatesAsync(new string[] { }, onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default)
         {
             var subscription = new CoinExTradesSubscription(_logger, this, symbols.ToArray(), new Dictionary<string, object>
             {
@@ -144,11 +144,11 @@ namespace CoinEx.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToIndexPriceUpdatesAsync(string symbol, Action<DataEvent<CoinExIndexPriceUpdate>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToIndexPriceUpdatesAsync(string symbol, Action<DataEvent<CoinExIndexPriceUpdate>> onMessage, CancellationToken ct = default)
             => SubscribeToIndexPriceUpdatesAsync(new[] { symbol }, onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToIndexPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExIndexPriceUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToIndexPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExIndexPriceUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, CoinExSocketUpdate<CoinExIndexPriceUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -168,11 +168,11 @@ namespace CoinEx.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(string symbol, Action<DataEvent<CoinExBookPriceUpdate>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(string symbol, Action<DataEvent<CoinExBookPriceUpdate>> onMessage, CancellationToken ct = default)
             => SubscribeToBookPriceUpdatesAsync(new[] { symbol }, onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExBookPriceUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExBookPriceUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, CoinExSocketUpdate<CoinExBookPriceUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -196,11 +196,11 @@ namespace CoinEx.Net.Clients.FuturesApi
 
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToPremiumIndexUpdatesAsync(string symbol, Action<DataEvent<CoinExPremiumUpdate>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToPremiumIndexUpdatesAsync(string symbol, Action<DataEvent<CoinExPremiumUpdate>> onMessage, CancellationToken ct = default)
             => SubscribeToPremiumIndexUpdatesAsync(new[] { symbol }, onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToPremiumIndexUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExPremiumUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToPremiumIndexUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExPremiumUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, CoinExSocketUpdate<CoinExPremiumUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -223,7 +223,7 @@ namespace CoinEx.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(Action<DataEvent<CoinExFuturesOrderUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(Action<DataEvent<CoinExFuturesOrderUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, CoinExSocketUpdate<CoinExFuturesOrderUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -246,7 +246,7 @@ namespace CoinEx.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToStopOrderUpdatesAsync(Action<DataEvent<CoinExStopOrderUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToStopOrderUpdatesAsync(Action<DataEvent<CoinExStopOrderUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, CoinExSocketUpdate<CoinExStopOrderUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -269,7 +269,7 @@ namespace CoinEx.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(Action<DataEvent<CoinExUserTrade>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(Action<DataEvent<CoinExUserTrade>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, CoinExSocketUpdate<CoinExUserTrade>>((receiveTime, originalData, invocations, data) =>
             {
@@ -291,7 +291,7 @@ namespace CoinEx.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(Action<DataEvent<CoinExFuturesBalance[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(Action<DataEvent<CoinExFuturesBalance[]>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, CoinExSocketUpdate<CoinExFuturesBalanceUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -309,7 +309,7 @@ namespace CoinEx.Net.Clients.FuturesApi
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(Action<DataEvent<CoinExPositionUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(Action<DataEvent<CoinExPositionUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, CoinExSocketUpdate<CoinExPositionUpdate>>((receiveTime, originalData, invocations, data) =>
             {

--- a/CoinEx.Net/Clients/FuturesApi/CoinExSocketClientFuturesApi.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExSocketClientFuturesApi.cs
@@ -42,8 +42,8 @@ namespace CoinEx.Net.Clients.FuturesApi
         /// <summary>
         /// Create a new instance of CoinExSocketClient with default options
         /// </summary>
-        internal CoinExSocketClientFuturesApi(ILogger logger, CoinExSocketOptions options)
-            : base(logger, CoinExExchange.Metadata.Id, options.Environment.SocketBaseAddress, options, options.FuturesOptions)
+        internal CoinExSocketClientFuturesApi(ILoggerFactory? loggerFactory, CoinExSocketOptions options)
+            : base(loggerFactory, CoinExExchange.Metadata.Id, options.Environment.SocketBaseAddress, options, options.FuturesOptions)
         {
             KeepAliveInterval = TimeSpan.Zero; // Server doesn't correctly respond to ping frames
 

--- a/CoinEx.Net/Clients/FuturesApi/CoinExSocketClientFuturesApiShared.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExSocketClientFuturesApiShared.cs
@@ -20,7 +20,7 @@ namespace CoinEx.Net.Clients.FuturesApi
         public TradingMode[] SupportedTradingModes => new[] { TradingMode.PerpetualLinear, TradingMode.PerpetualInverse };
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
-        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(CoinExExchange.Metadata, this);
 
         #region Tickers client
         SubscribeTickersOptions ITickersSocketClient.SubscribeAllTickersOptions { get; } = new SubscribeTickersOptions(_exchangeName);
@@ -30,7 +30,7 @@ namespace CoinEx.Net.Clients.FuturesApi
             if (validationError != null)
                 return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
-            var result = await SubscribeToTickerUpdatesAsync(update => handler(update.ToType(update.Data.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.OpenPrice == 0 ? null : Math.Round(x.LastPrice / x.OpenPrice * 100 - 100, 2))
+            var result = await SubscribeToTickerUpdatesAsync(update => handler(update.ToType(update.Data.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.OpenPrice == 0 ? null : Math.Round(x.LastPrice / x.OpenPrice * 100 - 100, 2))
             {
                 QuoteVolume = x.Value
             }).ToArray())), ct).ConfigureAwait(false);
@@ -56,7 +56,7 @@ namespace CoinEx.Net.Clients.FuturesApi
             {
                 foreach (var ticker in update.Data)
                 {
-                    handler(update.ToType(new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, ticker.Symbol), ticker.Symbol, ticker.LastPrice, ticker.HighPrice, ticker.LowPrice, ticker.Volume, Math.Round(ticker.LastPrice / ticker.OpenPrice * 100 - 100, 2))
+                    handler(update.ToType(new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, ticker.Symbol), ticker.Symbol, ticker.LastPrice, ticker.HighPrice, ticker.LowPrice, ticker.Volume, Math.Round(ticker.LastPrice / ticker.OpenPrice * 100 - 100, 2))
                     {
                         QuoteVolume = ticker.Value
                     }));
@@ -81,7 +81,7 @@ namespace CoinEx.Net.Clients.FuturesApi
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)) : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await SubscribeToTradeUpdatesAsync(symbols, update => handler(update.ToType(update.Data.Select(x => 
-                new SharedTrade(ExchangeSymbolCache.ParseSymbol(_topicId, update.Symbol), update.Symbol!, x.Quantity, x.Price, x.Timestamp)
+                new SharedTrade(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, update.Symbol), update.Symbol!, x.Quantity, x.Price, x.Timestamp)
             {
                 Side = x.Side == OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell
             }).ToArray())), ct).ConfigureAwait(false);
@@ -103,7 +103,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                 return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)) : [request.Symbol!.GetSymbol(FormatSymbol)];
-            var result = await SubscribeToBookPriceUpdatesAsync(symbols, update => handler(update.ToType(new SharedBookTicker(ExchangeSymbolCache.ParseSymbol(_topicId, update.Data.Symbol), update.Data.Symbol, update.Data.BestAskPrice, update.Data.BestAskQuantity, update.Data.BestBidPrice, update.Data.BestBidQuantity))), ct).ConfigureAwait(false);
+            var result = await SubscribeToBookPriceUpdatesAsync(symbols, update => handler(update.ToType(new SharedBookTicker(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, update.Data.Symbol), update.Data.Symbol, update.Data.BestAskPrice, update.Data.BestAskQuantity, update.Data.BestBidPrice, update.Data.BestBidQuantity))), ct).ConfigureAwait(false);
 
             return result;
         }
@@ -154,7 +154,7 @@ namespace CoinEx.Net.Clients.FuturesApi
             var result = await SubscribeToOrderUpdatesAsync(
                 update => handler(update.ToType<SharedFuturesOrder[]>(new[] {
                     new SharedFuturesOrder(
-                        ExchangeSymbolCache.ParseSymbol(_topicId, update.Data.Order.Symbol),
+                        ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, update.Data.Order.Symbol),
                         update.Data.Order.Symbol,
                         update.Data.Order.Id.ToString(),
                         update.Data.Order.OrderType == Enums.OrderTypeV2.Limit ? SharedOrderType.Limit : update.Data.Order.OrderType == Enums.OrderTypeV2.Market ? SharedOrderType.Market : SharedOrderType.Other,
@@ -188,7 +188,7 @@ namespace CoinEx.Net.Clients.FuturesApi
             var result = await SubscribeToUserTradeUpdatesAsync(
                 update => handler(update.ToType<SharedUserTrade[]>(new[] {
                     new SharedUserTrade(
-                        ExchangeSymbolCache.ParseSymbol(_topicId, update.Data.Symbol),
+                        ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, update.Data.Symbol),
                         update.Data.Symbol,
                         update.Data.OrderId.ToString(),
                         update.Data.Id.ToString(),
@@ -218,7 +218,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                 return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var result = await SubscribeToPositionUpdatesAsync(
-                update => handler(update.ToType<SharedPosition[]>(new[] { new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicId, update.Data.Position.Symbol), update.Data.Position.Symbol, update.Data.Position.OpenInterest, update.Data.Position.UpdateTime)
+                update => handler(update.ToType<SharedPosition[]>(new[] { new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, update.Data.Position.Symbol), update.Data.Position.Symbol, update.Data.Position.OpenInterest, update.Data.Position.UpdateTime)
                 {
                     AverageOpenPrice = update.Data.Position.AverageEntryPrice,
                     PositionMode = SharedPositionMode.OneWay,

--- a/CoinEx.Net/Clients/FuturesApi/CoinExSocketClientFuturesApiShared.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExSocketClientFuturesApiShared.cs
@@ -16,40 +16,40 @@ namespace CoinEx.Net.Clients.FuturesApi
     internal partial class CoinExSocketClientFuturesApi : ICoinExSocketClientFuturesApiShared
     {
         private const string _topicId = "CoinExFutures";
-
-        public string Exchange => CoinExExchange.ExchangeName;
-        public TradingMode[] SupportedTradingModes { get; } = new[] { TradingMode.PerpetualLinear, TradingMode.PerpetualInverse };
+        private const string _exchangeName = "CoinEx";
+        public TradingMode[] SupportedTradingModes => new[] { TradingMode.PerpetualLinear, TradingMode.PerpetualInverse };
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
 
         #region Tickers client
-        SubscribeTickersOptions ITickersSocketClient.SubscribeAllTickersOptions { get; } = new SubscribeTickersOptions();
-        async Task<ExchangeResult<UpdateSubscription>> ITickersSocketClient.SubscribeToAllTickersUpdatesAsync(SubscribeAllTickersRequest request, Action<DataEvent<SharedSpotTicker[]>> handler, CancellationToken ct)
+        SubscribeTickersOptions ITickersSocketClient.SubscribeAllTickersOptions { get; } = new SubscribeTickersOptions(_exchangeName);
+        async Task<WebSocketResult<UpdateSubscription>> ITickersSocketClient.SubscribeToAllTickersUpdatesAsync(SubscribeAllTickersRequest request, Action<DataEvent<SharedSpotTicker[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ITickersSocketClient)this).SubscribeAllTickersOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeAllTickersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var result = await SubscribeToTickerUpdatesAsync(update => handler(update.ToType(update.Data.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.OpenPrice == 0 ? null : Math.Round(x.LastPrice / x.OpenPrice * 100 - 100, 2))
             {
                 QuoteVolume = x.Value
             }).ToArray())), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion
 
         #region Ticker client
-        SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions()
+        SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions(_exchangeName)
         {
             SupportsMultipleSymbols = true
         };
-        async Task<ExchangeResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((ITickerSocketClient)this).SubscribeTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)) : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await SubscribeToTickerUpdatesAsync(symbols, update =>
@@ -63,21 +63,21 @@ namespace CoinEx.Net.Clients.FuturesApi
                 }
             }, ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Trade client
 
-        EndpointOptions<SubscribeTradeRequest> ITradeSocketClient.SubscribeTradeOptions { get; } = new EndpointOptions<SubscribeTradeRequest>(false)
+        SubscribeTradeOptions ITradeSocketClient.SubscribeTradeOptions { get; } = new SubscribeTradeOptions(_exchangeName, false)
         {
             SupportsMultipleSymbols = true
         };
-        async Task<ExchangeResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ITradeSocketClient)this).SubscribeTradeOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)) : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await SubscribeToTradeUpdatesAsync(symbols, update => handler(update.ToType(update.Data.Select(x => 
@@ -86,70 +86,70 @@ namespace CoinEx.Net.Clients.FuturesApi
                 Side = x.Side == OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell
             }).ToArray())), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Book Ticker client
 
-        EndpointOptions<SubscribeBookTickerRequest> IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new EndpointOptions<SubscribeBookTickerRequest>(false)
+        SubscribeBookTickerOptions IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new SubscribeBookTickerOptions(_exchangeName, false)
         {
             SupportsMultipleSymbols = true
         };
-        async Task<ExchangeResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((IBookTickerSocketClient)this).SubscribeBookTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeBookTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)) : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await SubscribeToBookPriceUpdatesAsync(symbols, update => handler(update.ToType(new SharedBookTicker(ExchangeSymbolCache.ParseSymbol(_topicId, update.Data.Symbol), update.Data.Symbol, update.Data.BestAskPrice, update.Data.BestAskQuantity, update.Data.BestBidPrice, update.Data.BestBidQuantity))), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Order Book client
-        SubscribeOrderBookOptions IOrderBookSocketClient.SubscribeOrderBookOptions { get; } = new SubscribeOrderBookOptions(false, new[] { 5, 10, 20, 50 })
+        SubscribeOrderBookOptions IOrderBookSocketClient.SubscribeOrderBookOptions { get; } = new SubscribeOrderBookOptions(_exchangeName, false, new[] { 5, 10, 20, 50 })
         {
             SupportsMultipleSymbols = true
         };
-        async Task<ExchangeResult<UpdateSubscription>> IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(SubscribeOrderBookRequest request, Action<DataEvent<SharedOrderBook>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(SubscribeOrderBookRequest request, Action<DataEvent<SharedOrderBook>> handler, CancellationToken ct)
         {
-            var validationError = ((IOrderBookSocketClient)this).SubscribeOrderBookOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeOrderBookOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)) : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await SubscribeToOrderBookUpdatesAsync(symbols, request.Limit ?? 20, null, true, update => handler(update.ToType(new SharedOrderBook(update.Data.Data.Asks, update.Data.Data.Bids))), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Balance client
-        EndpointOptions<SubscribeBalancesRequest> IBalanceSocketClient.SubscribeBalanceOptions { get; } = new EndpointOptions<SubscribeBalancesRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
+        SubscribeBalanceOptions IBalanceSocketClient.SubscribeBalanceOptions { get; } = new SubscribeBalanceOptions(_exchangeName, false);
+        async Task<WebSocketResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IBalanceSocketClient)this).SubscribeBalanceOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeBalanceOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
             var result = await SubscribeToBalanceUpdatesAsync(
                 update => handler(update.ToType(update.Data.Select(x => new SharedBalance(x.Asset, x.Available, x.Available + x.Frozen)).ToArray())),
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Spot Order client
 
-        EndpointOptions<SubscribeFuturesOrderRequest> IFuturesOrderSocketClient.SubscribeFuturesOrderOptions { get; } = new EndpointOptions<SubscribeFuturesOrderRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> IFuturesOrderSocketClient.SubscribeToFuturesOrderUpdatesAsync(SubscribeFuturesOrderRequest request, Action<DataEvent<SharedFuturesOrder[]>> handler, CancellationToken ct)
+        SubscribeFuturesOrderOptions IFuturesOrderSocketClient.SubscribeFuturesOrderOptions { get; } = new SubscribeFuturesOrderOptions(_exchangeName, false);
+        async Task<WebSocketResult<UpdateSubscription>> IFuturesOrderSocketClient.SubscribeToFuturesOrderUpdatesAsync(SubscribeFuturesOrderRequest request, Action<DataEvent<SharedFuturesOrder[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderSocketClient)this).SubscribeFuturesOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var result = await SubscribeToOrderUpdatesAsync(
                 update => handler(update.ToType<SharedFuturesOrder[]>(new[] {
@@ -173,17 +173,17 @@ namespace CoinEx.Net.Clients.FuturesApi
                 })),
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region User Trade client
-        EndpointOptions<SubscribeUserTradeRequest> IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new EndpointOptions<SubscribeUserTradeRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
+        SubscribeUserTradeOptions IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new SubscribeUserTradeOptions(_exchangeName, false);
+        async Task<WebSocketResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IUserTradeSocketClient)this).SubscribeUserTradeOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeUserTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var result = await SubscribeToUserTradeUpdatesAsync(
                 update => handler(update.ToType<SharedUserTrade[]>(new[] {
@@ -205,17 +205,17 @@ namespace CoinEx.Net.Clients.FuturesApi
                 })),
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Position client
-        EndpointOptions<SubscribePositionRequest> IPositionSocketClient.SubscribePositionOptions { get; } = new EndpointOptions<SubscribePositionRequest>(true);
-        async Task<ExchangeResult<UpdateSubscription>> IPositionSocketClient.SubscribeToPositionUpdatesAsync(SubscribePositionRequest request, Action<DataEvent<SharedPosition[]>> handler, CancellationToken ct)
+        SubscribePositionOptions IPositionSocketClient.SubscribePositionOptions { get; } = new SubscribePositionOptions(_exchangeName, true);
+        async Task<WebSocketResult<UpdateSubscription>> IPositionSocketClient.SubscribeToPositionUpdatesAsync(SubscribePositionRequest request, Action<DataEvent<SharedPosition[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IPositionSocketClient)this).SubscribePositionOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribePositionOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var result = await SubscribeToPositionUpdatesAsync(
                 update => handler(update.ToType<SharedPosition[]>(new[] { new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicId, update.Data.Position.Symbol), update.Data.Position.Symbol, update.Data.Position.OpenInterest, update.Data.Position.UpdateTime)
@@ -231,7 +231,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                 } })),
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion

--- a/CoinEx.Net/Clients/FuturesApi/CoinExSocketClientFuturesApiShared.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExSocketClientFuturesApiShared.cs
@@ -135,7 +135,12 @@ namespace CoinEx.Net.Clients.FuturesApi
             if (validationError != null)
                 return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
             var result = await SubscribeToBalanceUpdatesAsync(
-                update => handler(update.ToType(update.Data.Select(x => new SharedBalance(x.Asset, x.Available, x.Available + x.Frozen)).ToArray())),
+                update => handler(update.ToType(update.Data.Select(x => 
+                    new SharedBalance(
+                        SupportedTradingModes, 
+                        x.Asset,
+                        x.Available,
+                        x.Available + x.Frozen)).ToArray())),
                 ct: ct).ConfigureAwait(false);
 
             return result;

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApi.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApi.cs
@@ -50,8 +50,8 @@ namespace CoinEx.Net.Clients.SpotApiV2
         #endregion
 
         #region ctor
-        internal CoinExRestClientSpotApi(ILogger logger, HttpClient? httpClient, CoinExRestOptions options) :
-            base(logger, CoinExExchange.Metadata.Id, httpClient, options.Environment.RestBaseAddress, options, options.SpotOptions)
+        internal CoinExRestClientSpotApi(ILoggerFactory? loggerFactory, HttpClient? httpClient, CoinExRestOptions options) :
+            base(loggerFactory, CoinExExchange.Metadata.Id, httpClient, options.Environment.RestBaseAddress, options, options.SpotOptions)
         {
             Account = new CoinExRestClientSpotApiAccount(this);
             ExchangeData = new CoinExRestClientSpotApiExchangeData(this);

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApi.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApi.cs
@@ -51,7 +51,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
         #region ctor
         internal CoinExRestClientSpotApi(ILogger logger, HttpClient? httpClient, CoinExRestOptions options) :
-            base(logger, httpClient, options.Environment.RestBaseAddress, options, options.SpotOptions)
+            base(logger, CoinExExchange.Metadata.Id, httpClient, options.Environment.RestBaseAddress, options, options.SpotOptions)
         {
             Account = new CoinExRestClientSpotApiAccount(this);
             ExchangeData = new CoinExRestClientSpotApiExchangeData(this);
@@ -74,44 +74,38 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
         #region methods
 
-        internal Task<WebCallResult> SendAsync(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
-            => SendToAddressAsync(BaseAddress, definition, parameters, cancellationToken, weight);
-
-        internal async Task<WebCallResult> SendToAddressAsync(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null)
+        internal async Task<HttpResult> SendAsync(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
-            var result = await base.SendAsync<CoinExApiResult>(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
-            if (!result)
-                return result.AsDataless();
+            var result = await base.SendAsync<CoinExApiResult>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+            if (!result.Success)
+                return result;
 
             if (result.Data.Code != 0)
-                return result.AsDatalessError(new ServerError(result.Data.Code, GetErrorInfo(result.Data.Code, result.Data.Message!)));
+                return HttpResult.Fail(result, new ServerError(result.Data.Code, GetErrorInfo(result.Data.Code, result.Data.Message!)));
 
-            return result.AsDataless();
+            return result;
         }
 
-        internal Task<WebCallResult<T>> SendAsync<T>(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
-            => SendToAddressAsync<T>(BaseAddress, definition, parameters, cancellationToken, weight);
-
-        internal async Task<WebCallResult<T>> SendToAddressAsync<T>(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
+        internal async Task<HttpResult<T>> SendAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
-            var result = await base.SendAsync<CoinExApiResult<T>>(baseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
-            if (!result)
-                return result.As<T>(default);
+            var result = await base.SendAsync<CoinExApiResult<T>>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+            if (!result.Success)
+                return HttpResult.Fail<T>(result);
 
             if (result.Data.Code != 0)
-                return result.AsError<T>(new ServerError(result.Data.Code, GetErrorInfo(result.Data.Code, result.Data.Message!)));
+                return HttpResult.Fail<T>(result, new ServerError(result.Data.Code, GetErrorInfo(result.Data.Code, result.Data.Message!)));
 
-            return result.As(result.Data.Data);
+            return HttpResult.Ok(result, result.Data.Data);
         }
 
-        internal async Task<WebCallResult<CoinExPaginated<T>>> SendPaginatedAsync<T>(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null) where T : class
+        internal async Task<HttpResult<CoinExPaginated<T>>> SendPaginatedAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null)
         {
-            var result = await base.SendAsync<CoinExPageApiResult<T[]>>(BaseAddress, definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
-            if (!result)
-                return result.As<CoinExPaginated<T>>(default);
+            var result = await base.SendAsync<CoinExPageApiResult<T[]>>(definition, parameters, cancellationToken, null, weight).ConfigureAwait(false);
+            if (!result.Success)
+                return HttpResult.Fail<CoinExPaginated<T>>(result);
 
             if (result.Data.Code != 0)
-                return result.AsError<CoinExPaginated<T>>(new ServerError(result.Data.Code, GetErrorInfo(result.Data.Code, result.Data.Message!)));
+                return HttpResult.Fail<CoinExPaginated<T>>(result, new ServerError(result.Data.Code, GetErrorInfo(result.Data.Code, result.Data.Message!)));
 
             var resultPage = new CoinExPaginated<T>
             {
@@ -120,12 +114,12 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 Items = result.Data.Data
             };
 
-            return result.As(resultPage);
+            return HttpResult.Ok(result, resultPage);
         }
         #endregion
 
         /// <inheritdoc />
-        protected override async Task<WebCallResult<DateTime>> GetServerTimestampAsync() => await ExchangeData.GetServerTimeAsync().ConfigureAwait(false);
+        protected override async Task<HttpResult<DateTime>> GetServerTimestampAsync() => await ExchangeData.GetServerTimeAsync().ConfigureAwait(false);
 
         /// <inheritdoc />
         public ICoinExRestClientSpotApiShared SharedClient => this;

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiAccount.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiAccount.cs
@@ -23,281 +23,281 @@ namespace CoinEx.Net.Clients.SpotApiV2
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExTradeFee>> GetTradingFeesAsync(string symbol, AccountType accountType, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExTradeFee>> GetTradingFeesAsync(string symbol, AccountType accountType, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddEnum("market_type", accountType);
+            parameters.Add("market_type", accountType);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/account/trade-fee-rate", CoinExExchange.RateLimiter.CoinExRestSpotAccountQuery, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/account/trade-fee-rate", CoinExExchange.RateLimiter.CoinExRestSpotAccountQuery, 1, true);
             return await _baseClient.SendAsync<CoinExTradeFee>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult> SetAccountConfigAsync(bool cetDiscountEnabled, CancellationToken ct = default)
+        public async Task<HttpResult> SetAccountConfigAsync(bool cetDiscountEnabled, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "cet_discount_enabled", cetDiscountEnabled }
             };
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/account/settings", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/account/settings", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
             return await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExBalance[]>> GetBalancesAsync(CancellationToken ct = default)
+        public async Task<HttpResult<CoinExBalance[]>> GetBalancesAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/assets/spot/balance", CoinExExchange.RateLimiter.CoinExRestSpotAccountQuery, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/assets/spot/balance", CoinExExchange.RateLimiter.CoinExRestSpotAccountQuery, 1, true);
             return await _baseClient.SendAsync<CoinExBalance[]>(request, null, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExMarginBalance[]>> GetMarginBalancesAsync(CancellationToken ct = default)
+        public async Task<HttpResult<CoinExMarginBalance[]>> GetMarginBalancesAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/assets/margin/balance", CoinExExchange.RateLimiter.CoinExRestSpotAccountQuery, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/assets/margin/balance", CoinExExchange.RateLimiter.CoinExRestSpotAccountQuery, 1, true);
             return await _baseClient.SendAsync<CoinExMarginBalance[]>(request, null, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExBalance[]>> GetFinancialBalancesAsync(CancellationToken ct = default)
+        public async Task<HttpResult<CoinExBalance[]>> GetFinancialBalancesAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/assets/financial/balance", CoinExExchange.RateLimiter.CoinExRestSpotAccountQuery, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/assets/financial/balance", CoinExExchange.RateLimiter.CoinExRestSpotAccountQuery, 1, true);
             return await _baseClient.SendAsync<CoinExBalance[]>(request, null, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExCreditBalance>> GetCreditAccountAsync(CancellationToken ct = default)
+        public async Task<HttpResult<CoinExCreditBalance>> GetCreditAccountAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/assets/credit/info", CoinExExchange.RateLimiter.CoinExRestSpotAccountQuery, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/assets/credit/info", CoinExExchange.RateLimiter.CoinExRestSpotAccountQuery, 1, true);
             return await _baseClient.SendAsync<CoinExCreditBalance>(request, null, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExAmmBalance[]>> GetAutoMarketMakerAccountLiquidityAsync(CancellationToken ct = default)
+        public async Task<HttpResult<CoinExAmmBalance[]>> GetAutoMarketMakerAccountLiquidityAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/assets/amm/liquidity", CoinExExchange.RateLimiter.CoinExRestSpotAccountQuery, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/assets/amm/liquidity", CoinExExchange.RateLimiter.CoinExRestSpotAccountQuery, 1, true);
             return await _baseClient.SendAsync<CoinExAmmBalance[]>(request, null, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExBorrow>> MarginBorrowAsync(string symbol, string asset, decimal quantity, bool autoRenew, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExBorrow>> MarginBorrowAsync(string symbol, string asset, decimal quantity, bool autoRenew, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "ccy", asset },
                 { "is_auto_renew", autoRenew }
             };
-            parameters.AddString("borrow_amount", quantity);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/assets/margin/borrow", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
+            parameters.Add("borrow_amount", quantity);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/assets/margin/borrow", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
             return await _baseClient.SendAsync<CoinExBorrow> (request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult> MarginRepayAsync(string symbol, string asset, decimal quantity, long? borrowId = null, CancellationToken ct = default)
+        public async Task<HttpResult> MarginRepayAsync(string symbol, string asset, decimal quantity, long? borrowId = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "ccy", asset },
             };
-            parameters.AddString("borrow_amount", quantity);
-            parameters.AddOptional("borrow_id", borrowId);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/assets/margin/repay", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
+            parameters.Add("borrow_amount", quantity);
+            parameters.Add("borrow_id", borrowId);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/assets/margin/repay", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
             return await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExBorrow>>> GetBorrowHistoryAsync(string? symbol = null, BorrowStatus? status = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExBorrow>>> GetBorrowHistoryAsync(string? symbol = null, BorrowStatus? status = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbol);
-            parameters.AddOptionalEnum("status", status);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/assets/margin/borrow-history", CoinExExchange.RateLimiter.CoinExRestSpotAccountHistory, 1, true);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market", symbol);
+            parameters.Add("status", status);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/assets/margin/borrow-history", CoinExExchange.RateLimiter.CoinExRestSpotAccountHistory, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExBorrow>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExBorrowLimit>> GetBorrowLimitAsync(string symbol, string asset, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExBorrowLimit>> GetBorrowLimitAsync(string symbol, string asset, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "ccy", asset },
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/assets/margin/interest-limit", CoinExExchange.RateLimiter.CoinExRestSpotAccountQuery, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/assets/margin/interest-limit", CoinExExchange.RateLimiter.CoinExRestSpotAccountQuery, 1, true);
             return await _baseClient.SendAsync<CoinExBorrowLimit>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExDepositAddress>> GetDepositAddressAsync(string asset, string network, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExDepositAddress>> GetDepositAddressAsync(string asset, string network, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "chain", network },
                 { "ccy", asset },
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/assets/deposit-address", CoinExExchange.RateLimiter.CoinExRestSpotAccountQuery, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/assets/deposit-address", CoinExExchange.RateLimiter.CoinExRestSpotAccountQuery, 1, true);
             return await _baseClient.SendAsync<CoinExDepositAddress>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExDepositAddress>> RenewDepositAddressAsync(string asset, string network, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExDepositAddress>> RenewDepositAddressAsync(string asset, string network, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "chain", network },
                 { "ccy", asset },
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/assets/renewal-deposit-address", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/assets/renewal-deposit-address", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
             return await _baseClient.SendAsync<CoinExDepositAddress>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExDeposit>>> GetDepositHistoryAsync(string? asset = null, string? transactionId = null, DepositStatus? status = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExDeposit>>> GetDepositHistoryAsync(string? asset = null, string? transactionId = null, DepositStatus? status = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("ccy", asset);
-            parameters.AddOptional("tx_id", transactionId);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            parameters.AddOptionalEnum("status", status);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/assets/deposit-history", CoinExExchange.RateLimiter.CoinExRestSpotAccountHistory, 1, true);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("ccy", asset);
+            parameters.Add("tx_id", transactionId);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            parameters.Add("status", status);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/assets/deposit-history", CoinExExchange.RateLimiter.CoinExRestSpotAccountHistory, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExDeposit>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExWithdrawal>> WithdrawAsync(string asset, decimal quantity, string toAddress, MovementMethod? method = null, string? network = null, string? remark = null, string? memo = null, Dictionary<string, object>? extraParameters = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExWithdrawal>> WithdrawAsync(string asset, decimal quantity, string toAddress, MovementMethod? method = null, string? network = null, string? remark = null, string? memo = null, Dictionary<string, object>? extraParameters = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "ccy", asset },
                 { "to_address", toAddress },
             };
-            parameters.AddOptionalEnum("withdraw_method", method);
-            parameters.AddString("amount", quantity);
-            parameters.AddOptional("chain", network);
-            parameters.AddOptional("remark", remark);
-            parameters.AddOptional("memo", memo);
-            parameters.AddOptional("extra", extraParameters);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/assets/withdraw", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
+            parameters.Add("withdraw_method", method);
+            parameters.Add("amount", quantity);
+            parameters.Add("chain", network);
+            parameters.Add("remark", remark);
+            parameters.Add("memo", memo);
+            parameters.AddRaw("extra", extraParameters);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/assets/withdraw", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
             return await _baseClient.SendAsync<CoinExWithdrawal>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult> CancelWithdrawalAsync(long withdrawalId, CancellationToken ct = default)
+        public async Task<HttpResult> CancelWithdrawalAsync(long withdrawalId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "withdraw_id", withdrawalId }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/assets/cancel-withdraw", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/assets/cancel-withdraw", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
             return await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExWithdrawal>>> GetWithdrawalHistoryAsync(string? asset = null, long? withdrawId = null, WithdrawStatusV2? status = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExWithdrawal>>> GetWithdrawalHistoryAsync(string? asset = null, long? withdrawId = null, WithdrawStatusV2? status = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("ccy", asset);
-            parameters.AddOptional("withdraw_id", withdrawId);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            parameters.AddOptionalEnum("status", status);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/assets/withdraw", CoinExExchange.RateLimiter.CoinExRestSpotAccountHistory, 1, true);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("ccy", asset);
+            parameters.Add("withdraw_id", withdrawId);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            parameters.Add("status", status);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/assets/withdraw", CoinExExchange.RateLimiter.CoinExRestSpotAccountHistory, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExWithdrawal>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExDepositWithdrawalConfig>> GetDepositWithdrawalConfigAsync(string asset, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExDepositWithdrawalConfig>> GetDepositWithdrawalConfigAsync(string asset, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("ccy", asset);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/assets/deposit-withdraw-config", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false,
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("ccy", asset);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/assets/deposit-withdraw-config", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false,
                 new SingleLimitGuard(10, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding));
             return await _baseClient.SendAsync<CoinExDepositWithdrawalConfig>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExDepositWithdrawalConfig[]>> GetAllDepositWithdrawalConfigsAsync(CancellationToken ct = default)
+        public async Task<HttpResult<CoinExDepositWithdrawalConfig[]>> GetAllDepositWithdrawalConfigsAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/assets/all-deposit-withdraw-config", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false,
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/assets/all-deposit-withdraw-config", CoinExExchange.RateLimiter.CoinExRestPublic, 1, false,
                 new SingleLimitGuard(10, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding));
             return await _baseClient.SendAsync<CoinExDepositWithdrawalConfig[]>(request, null, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult> TransferAsync(string asset, AccountType fromAccount, AccountType toAccount, decimal quantity, string? marginSymbol = null, CancellationToken ct = default)
+        public async Task<HttpResult> TransferAsync(string asset, AccountType fromAccount, AccountType toAccount, decimal quantity, string? marginSymbol = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "ccy", asset }
             };
-            parameters.AddEnum("from_account_type", fromAccount);
-            parameters.AddEnum("to_account_type", toAccount);
-            parameters.AddString("amount", quantity);
-            parameters.AddOptional("market", marginSymbol);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/assets/transfer", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
+            parameters.Add("from_account_type", fromAccount);
+            parameters.Add("to_account_type", toAccount);
+            parameters.Add("amount", quantity);
+            parameters.Add("market", marginSymbol);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/assets/transfer", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
             return await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExTransfer>>> GetTransfersAsync(string asset, AccountType transferType, TransferStatus? status = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExTransfer>>> GetTransfersAsync(string asset, AccountType transferType, TransferStatus? status = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "ccy", asset }
             };
-            parameters.AddEnum("transfer_type", transferType);
-            parameters.AddOptionalMilliseconds("start_time", startTime);
-            parameters.AddOptionalMilliseconds("end_time", endTime);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            parameters.AddOptionalEnum("status", status);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/assets/transfer-history", CoinExExchange.RateLimiter.CoinExRestSpotAccountHistory, 1, true);
+            parameters.Add("transfer_type", transferType);
+            parameters.Add("start_time", startTime);
+            parameters.Add("end_time", endTime);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            parameters.Add("status", status);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/assets/transfer-history", CoinExExchange.RateLimiter.CoinExRestSpotAccountHistory, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExTransfer>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExAamLiquidity>> AddAutoMarketMakerLiquidityAsync(string symbol, decimal baseAssetQuantity, decimal quoteAssetQuantity, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExAamLiquidity>> AddAutoMarketMakerLiquidityAsync(string symbol, decimal baseAssetQuantity, decimal quoteAssetQuantity, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddString("base_ccy_amount", baseAssetQuantity);
-            parameters.AddString("quote_ccy_amount", quoteAssetQuantity);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/assets/amm/add-liquidity", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
+            parameters.Add("base_ccy_amount", baseAssetQuantity);
+            parameters.Add("quote_ccy_amount", quoteAssetQuantity);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/assets/amm/add-liquidity", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
             return await _baseClient.SendAsync<CoinExAamLiquidity>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExAamLiquidity>> RemoveAutoMarketMakerLiquidityAsync(string symbol, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExAamLiquidity>> RemoveAutoMarketMakerLiquidityAsync(string symbol, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/assets/amm/remove-liquidity", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/assets/amm/remove-liquidity", CoinExExchange.RateLimiter.CoinExRestSpotAccount, 1, true);
             return await _baseClient.SendAsync<CoinExAamLiquidity>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExTransaction>>> GetTransactionHistoryAsync(TransactionType transactionType, string? asset = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExTransaction>>> GetTransactionHistoryAsync(TransactionType transactionType, string? asset = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("ccy", asset);
-            parameters.AddEnum("type", transactionType);
-            parameters.AddOptionalMilliseconds("start_time", startTime);
-            parameters.AddOptionalMilliseconds("end_time", endTime);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/assets/spot/transcation-history", CoinExExchange.RateLimiter.CoinExRestSpotAccountHistory, 1, true);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("ccy", asset);
+            parameters.Add("type", transactionType);
+            parameters.Add("start_time", startTime);
+            parameters.Add("end_time", endTime);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/assets/spot/transcation-history", CoinExExchange.RateLimiter.CoinExRestSpotAccountHistory, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExTransaction>(request, parameters, ct).ConfigureAwait(false);
         }
     }

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiExchangeData.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiExchangeData.cs
@@ -23,71 +23,74 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
 
         /// <inheritdoc />
-        public async Task<WebCallResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default)
+        public async Task<HttpResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/time", CoinExExchange.RateLimiter.CoinExRestPublic);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/time", CoinExExchange.RateLimiter.CoinExRestPublic);
             var result = await _baseClient.SendAsync<CoinExServerTime>(request, null, ct).ConfigureAwait(false);
-            return result.As(result.Data?.ServerTime ?? default);
+            if (!result.Success)
+                return HttpResult.Fail<DateTime>(result);
+
+            return HttpResult.Ok(result, result.Data.ServerTime);
         }
 
         // Doesn't seem to exist on the url specified in the docs
         ///// <inheritdoc />
-        //public async Task<WebCallResult<CoinExMaintenance[]>> GetMaintenanceInfoAsync(CancellationToken ct = default)
+        //public async Task<HttpResult<CoinExMaintenance[]>> GetMaintenanceInfoAsync(CancellationToken ct = default)
         //{
         //    return await _baseClient.ExecuteAsync<IEnumerable<CoinExMaintenance>>(_baseClient.GetUri("v2/maintain-info"), HttpMethod.Get, ct).ConfigureAwait(false);
         //}
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExSymbol[]>> GetSymbolsAsync(CancellationToken ct = default)
+        public async Task<HttpResult<CoinExSymbol[]>> GetSymbolsAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/spot/market", CoinExExchange.RateLimiter.CoinExRestPublic);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/spot/market", CoinExExchange.RateLimiter.CoinExRestPublic);
             return await _baseClient.SendAsync<CoinExSymbol[]>(request, null, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExAsset[]>> GetAssetsAsync(CancellationToken ct = default)
+        public async Task<HttpResult<CoinExAsset[]>> GetAssetsAsync(CancellationToken ct = default)
         {
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/assets/info", CoinExExchange.RateLimiter.CoinExRestPublic);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/assets/info", CoinExExchange.RateLimiter.CoinExRestPublic);
             return await _baseClient.SendAsync<CoinExAsset[]>(request, null, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExTicker[]>> GetTickersAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExTicker[]>> GetTickersAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbols == null ? null : string.Join(",", symbols));
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/spot/ticker", CoinExExchange.RateLimiter.CoinExRestPublic);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market", symbols == null ? null : string.Join(",", symbols));
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/spot/ticker", CoinExExchange.RateLimiter.CoinExRestPublic);
             return await _baseClient.SendAsync<CoinExTicker[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExOrderBook>> GetOrderBookAsync(string symbol, int limit, string? mergeLevel = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExOrderBook>> GetOrderBookAsync(string symbol, int limit, string? mergeLevel = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "limit", limit },
                 { "interval", mergeLevel ?? "0" }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/spot/depth", CoinExExchange.RateLimiter.CoinExRestPublic);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/spot/depth", CoinExExchange.RateLimiter.CoinExRestPublic);
             return await _baseClient.SendAsync<CoinExOrderBook>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExTrade[]>> GetTradeHistoryAsync(string symbol, int? limit = null, long? lastId = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExTrade[]>> GetTradeHistoryAsync(string symbol, int? limit = null, long? lastId = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptional("last_id", lastId);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/spot/deals", CoinExExchange.RateLimiter.CoinExRestPublic);
+            parameters.Add("limit", limit);
+            parameters.Add("last_id", lastId);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/spot/deals", CoinExExchange.RateLimiter.CoinExRestPublic);
             return await _baseClient.SendAsync<CoinExTrade[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExKline[]>> GetKlinesAsync(
+        public async Task<HttpResult<CoinExKline[]>> GetKlinesAsync(
             string symbol,
             KlineInterval interval, 
             int? limit = null,
@@ -96,25 +99,25 @@ namespace CoinEx.Net.Clients.SpotApiV2
             DateTime? endTime = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddEnum("period", interval);
-            parameters.AddOptionalEnum("price_type", priceType);
-            parameters.AddOptional("limit", limit);
-            parameters.AddOptionalMilliseconds("start_time", startTime);
-            parameters.AddOptionalMilliseconds("end_time", endTime);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/spot/kline", CoinExExchange.RateLimiter.CoinExRestPublic);
+            parameters.Add("period", interval);
+            parameters.Add("price_type", priceType);
+            parameters.Add("limit", limit);
+            parameters.Add("start_time", startTime);
+            parameters.Add("end_time", endTime);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/spot/kline", CoinExExchange.RateLimiter.CoinExRestPublic);
             return await _baseClient.SendAsync<CoinExKline[]>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExIndexPrice[]>> GetIndexPricesAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExIndexPrice[]>> GetIndexPricesAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddOptional("market", symbols == null ? null : string.Join(",", symbols));
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/spot/index", CoinExExchange.RateLimiter.CoinExRestPublic);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market", symbols == null ? null : string.Join(",", symbols));
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/spot/index", CoinExExchange.RateLimiter.CoinExRestPublic);
             return await _baseClient.SendAsync<CoinExIndexPrice[]>(request, parameters, ct).ConfigureAwait(false);
         }
     }

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiShared.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiShared.cs
@@ -22,7 +22,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
-        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(CoinExExchange.Metadata, this);
 
         #region Kline client
 
@@ -116,19 +116,19 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 QuantityDecimals = s.QuantityPrecision
             }).ToArray());
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, response.Data!);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, response.Data!);
             return response;
         }
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicId))
+            if (!ExchangeSymbolCache.HasCached(_topicId, EnvironmentName, null))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, EnvironmentName, null, baseAsset));
         }
 
         async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
@@ -136,26 +136,26 @@ namespace CoinEx.Net.Clients.SpotApiV2
             if (symbol.TradingMode != TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Only Spot symbols allowed");
 
-            if (!ExchangeSymbolCache.HasCached(_topicId))
+            if (!ExchangeSymbolCache.HasCached(_topicId, EnvironmentName, null))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, EnvironmentName, null, symbol));
         }
 
         async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicId))
+            if (!ExchangeSymbolCache.HasCached(_topicId, EnvironmentName, null))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, EnvironmentName, null, symbolName));
         }
         #endregion
 
@@ -173,7 +173,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 return HttpResult.Fail<SharedSpotTicker>(result);
 
             var ticker = result.Data.Single();
-            return HttpResult.Ok(result, new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, ticker.Symbol), ticker.Symbol, ticker.LastPrice, ticker.HighPrice, ticker.LowPrice, ticker.Volume, ticker.OpenPrice == 0 ? null : Math.Round(ticker.LastPrice / ticker.OpenPrice * 100 - 100, 2))
+            return HttpResult.Ok(result, new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, ticker.Symbol), ticker.Symbol, ticker.LastPrice, ticker.HighPrice, ticker.LowPrice, ticker.Volume, ticker.OpenPrice == 0 ? null : Math.Round(ticker.LastPrice / ticker.OpenPrice * 100 - 100, 2))
             {
                 QuoteVolume = ticker.Value
             });
@@ -190,7 +190,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
             if (!result.Success)
                 return HttpResult.Fail<SharedSpotTicker[]>(result);
 
-            return HttpResult.Ok(result, result.Data.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.OpenPrice == 0 ? null : Math.Round(x.LastPrice / x.OpenPrice * 100 - 100, 2))
+            return HttpResult.Ok(result, result.Data.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.OpenPrice == 0 ? null : Math.Round(x.LastPrice / x.OpenPrice * 100 - 100, 2))
             {
                 QuoteVolume = x.Value
             }).ToArray());
@@ -212,7 +212,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 return HttpResult.Fail<SharedBookTicker>(resultTicker);
 
             return HttpResult.Ok(resultTicker, new SharedBookTicker(
-                ExchangeSymbolCache.ParseSymbol(_topicId, resultTicker.Data.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, resultTicker.Data.Symbol),
                 resultTicker.Data.Symbol,
                 resultTicker.Data.Data.Asks[0].Price,
                 resultTicker.Data.Data.Asks[0].Quantity,
@@ -341,7 +341,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 return HttpResult.Fail<SharedSpotOrder>(orders);
 
             return HttpResult.Ok(orders, new SharedSpotOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicId, orders.Data.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, orders.Data.Symbol),
                 orders.Data.Symbol,
                 orders.Data.Id.ToString(),
                 ParseOrderType(orders.Data.OrderType),
@@ -374,7 +374,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 return HttpResult.Fail<SharedSpotOrder[]>(orders);
 
             return HttpResult.Ok(orders, orders.Data.Items.Select(x => new SharedSpotOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol), 
                 x.Symbol,
                 x.Id.ToString(),
                 ParseOrderType(x.OrderType),
@@ -426,7 +426,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                     .Select(x => new SharedSpotOrder(
-                        ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
+                        ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol), 
                         x.Symbol,
                         x.Id.ToString(),
                         ParseOrderType(x.OrderType),
@@ -461,7 +461,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 return HttpResult.Fail<SharedUserTrade[]>(orders);
 
             return HttpResult.Ok(orders, orders.Data.Items.Select(x => new SharedUserTrade(
-                ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString(),
                 x.Id.ToString(),
@@ -511,7 +511,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                     .Select(x => new SharedUserTrade(
-                        ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
+                        ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol), 
                         x.Symbol,
                         x.OrderId.ToString(),
                         x.Id.ToString(),
@@ -606,7 +606,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 return HttpResult.Fail<SharedSpotOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
             return HttpResult.Ok(order, new SharedSpotOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicId, orderData.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, orderData.Symbol),
                 orderData.Symbol,
                 orderData.Id.ToString(),
                 ParseOrderType(orderData.OrderType),
@@ -993,7 +993,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
             }
 
             return HttpResult.Ok(orders, new SharedSpotTriggerOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicId, order.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, order.Symbol),
                 order.Symbol,
                 order.ClientOrderId?.ToString() ?? order.StopOrderId.ToString(),
                 ParseOrderType(order.Type),

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiShared.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiShared.cs
@@ -264,7 +264,12 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 if (!result.Success)
                 return HttpResult.Fail<SharedBalance[]>(result);
 
-                return HttpResult.Ok(result, result.Data.Select(x => new SharedBalance(x.Asset, x.Available, x.Available + x.Frozen)).ToArray());
+                return HttpResult.Ok(result, result.Data.Select(x => 
+                    new SharedBalance(
+                        SupportedTradingModes, 
+                        x.Asset,
+                        x.Available, 
+                        x.Available + x.Frozen)).ToArray());
             }
             else
             {
@@ -275,8 +280,20 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 var resultList = new List<SharedBalance>();
                 foreach(var item in result.Data)
                 {
-                    resultList.Add(new SharedBalance(item.BaseAsset, item.Available.BaseAsset, item.Available.BaseAsset + item.Frozen.BaseAsset) { IsolatedMarginSymbol = item.MarginAccount });
-                    resultList.Add(new SharedBalance(item.QuoteAsset, item.Available.QuoteAsset, item.Available.QuoteAsset + item.Frozen.QuoteAsset) { IsolatedMarginSymbol = item.MarginAccount });
+                    resultList.Add(
+                        new SharedBalance(
+                            SupportedTradingModes,
+                            item.BaseAsset, 
+                            item.Available.BaseAsset,
+                            item.Available.BaseAsset + item.Frozen.BaseAsset)
+                        { IsolatedMarginSymbol = item.MarginAccount });
+                    resultList.Add(
+                        new SharedBalance(
+                            SupportedTradingModes,
+                            item.QuoteAsset,
+                            item.Available.QuoteAsset,
+                            item.Available.QuoteAsset + item.Frozen.QuoteAsset)
+                        { IsolatedMarginSymbol = item.MarginAccount });
                 }
 
                 return HttpResult.Ok(result, resultList.ToArray());

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiShared.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiShared.cs
@@ -17,16 +17,16 @@ namespace CoinEx.Net.Clients.SpotApiV2
     internal partial class CoinExRestClientSpotApi : ICoinExRestClientSpotApiShared
     {
         private const string _topicId = "CoinExSpot";
-
-        public string Exchange => CoinExExchange.ExchangeName;
-        public TradingMode[] SupportedTradingModes { get; } = new[] { TradingMode.Spot };
+        private const string _exchangeName = "CoinEx";
+        public TradingMode[] SupportedTradingModes => new[] { TradingMode.Spot };
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
 
         #region Kline client
 
-        GetKlinesOptions IKlineRestClient.GetKlinesOptions { get; } = new GetKlinesOptions(true, true, true, 1000, false,
+        GetKlinesOptions IKlineRestClient.GetKlinesOptions { get; } = new GetKlinesOptions(_exchangeName, true, true, true, 1000, false,
             SharedKlineInterval.OneMinute,
             SharedKlineInterval.FiveMinutes,
             SharedKlineInterval.FifteenMinutes,
@@ -41,15 +41,13 @@ namespace CoinEx.Net.Clients.SpotApiV2
         {
         };
 
-        async Task<ExchangeWebResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
             var interval = (Enums.KlineInterval)request.Interval;
-            if (!Enum.IsDefined(typeof(Enums.KlineInterval), interval))
-                return new ExchangeWebResult<SharedKline[]>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
-            var validationError = ((IKlineRestClient)this).GetKlinesOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetKlinesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedKline[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedKline[]>(Exchange, validationError);
 
             var direction = request.Direction ?? DataDirection.Ascending;
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
@@ -65,8 +63,8 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 limit: limit,
                 ct: ct
                 ).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedKline[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedKline[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                     () =>
@@ -82,10 +80,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
                     request.EndTime ?? DateTime.UtcNow,
                     pageParams);
 
-            return result.AsExchangeResult(
-                   Exchange,
-                   TradingMode.Spot,
-                   ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.OpenTime, request.StartTime, request.EndTime, direction)
                    .Select(x => 
                        new SharedKline(
                            request.Symbol, 
@@ -103,40 +98,40 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
         #region Spot Symbol client
 
-        EndpointOptions<GetSymbolsRequest> ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest>(false);
-        async Task<ExchangeWebResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
+        GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
+        async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotSymbolRestClient)this).GetSpotSymbolsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotSymbolsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotSymbol[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotSymbol[]>(Exchange, validationError);
 
             var result = await ExchangeData.GetSymbolsAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotSymbol[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotSymbol[]>(result);
 
-            var response = result.AsExchangeResult<SharedSpotSymbol[]>(Exchange, TradingMode.Spot, result.Data.Select(s => new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Name, true)
+            var response = HttpResult.Ok(result, result.Data.Select(s => new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Name, true)
             {
                 MinTradeQuantity = s.MinOrderQuantity,
                 PriceDecimals = s.PricePrecision,
                 QuantityDecimals = s.QuantityPrecision
             }).ToArray());
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, response.Data);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, response.Data!);
             return response;
         }
-        async Task<ExchangeResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
+        async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
         {
             if (!ExchangeSymbolCache.HasCached(_topicId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<SharedSymbol[]>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<SharedSymbol[]>(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicId, baseAsset));
         }
 
-        async Task<ExchangeResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
+        async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
         {
             if (symbol.TradingMode != TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Only Spot symbols allowed");
@@ -144,58 +139,58 @@ namespace CoinEx.Net.Clients.SpotApiV2
             if (!ExchangeSymbolCache.HasCached(_topicId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbol));
         }
 
-        async Task<ExchangeResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
+        async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
         {
             if (!ExchangeSymbolCache.HasCached(_topicId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicId, symbolName));
         }
         #endregion
 
         #region Ticker client
 
-        GetTickerOptions ISpotTickerRestClient.GetSpotTickerOptions { get; } = new GetTickerOptions();
-        async Task<ExchangeWebResult<SharedSpotTicker>> ISpotTickerRestClient.GetSpotTickerAsync(GetTickerRequest request, CancellationToken ct)
+        GetSpotTickerOptions ISpotTickerRestClient.GetSpotTickerOptions { get; } = new GetSpotTickerOptions(_exchangeName);
+        async Task<HttpResult<SharedSpotTicker>> ISpotTickerRestClient.GetSpotTickerAsync(GetTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTickerRestClient)this).GetSpotTickerOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotTicker>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotTicker>(Exchange, validationError);
 
             var result = await ExchangeData.GetTickersAsync(new[] { request.Symbol!.GetSymbol(FormatSymbol) }, ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotTicker>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotTicker>(result);
 
             var ticker = result.Data.Single();
-            return result.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, ticker.Symbol), ticker.Symbol, ticker.LastPrice, ticker.HighPrice, ticker.LowPrice, ticker.Volume, ticker.OpenPrice == 0 ? null : Math.Round(ticker.LastPrice / ticker.OpenPrice * 100 - 100, 2))
+            return HttpResult.Ok(result, new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, ticker.Symbol), ticker.Symbol, ticker.LastPrice, ticker.HighPrice, ticker.LowPrice, ticker.Volume, ticker.OpenPrice == 0 ? null : Math.Round(ticker.LastPrice / ticker.OpenPrice * 100 - 100, 2))
             {
                 QuoteVolume = ticker.Value
             });
         }
 
-        GetTickersOptions ISpotTickerRestClient.GetSpotTickersOptions { get; } = new GetTickersOptions();
-        async Task<ExchangeWebResult<SharedSpotTicker[]>> ISpotTickerRestClient.GetSpotTickersAsync(GetTickersRequest request, CancellationToken ct)
+        GetSpotTickersOptions ISpotTickerRestClient.GetSpotTickersOptions { get; } = new GetSpotTickersOptions(_exchangeName);
+        async Task<HttpResult<SharedSpotTicker[]>> ISpotTickerRestClient.GetSpotTickersAsync(GetTickersRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTickerRestClient)this).GetSpotTickersOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotTickersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotTicker[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotTicker[]>(Exchange, validationError);
 
             var result = await ExchangeData.GetTickersAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotTicker[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotTicker[]>(result);
 
-            return result.AsExchangeResult<SharedSpotTicker[]>(Exchange, TradingMode.Spot, result.Data.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.OpenPrice == 0 ? null : Math.Round(x.LastPrice / x.OpenPrice * 100 - 100, 2))
+            return HttpResult.Ok(result, result.Data.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.OpenPrice == 0 ? null : Math.Round(x.LastPrice / x.OpenPrice * 100 - 100, 2))
             {
                 QuoteVolume = x.Value
             }).ToArray());
@@ -205,18 +200,18 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
         #region Book Ticker client
 
-        EndpointOptions<GetBookTickerRequest> IBookTickerRestClient.GetBookTickerOptions { get; } = new EndpointOptions<GetBookTickerRequest>(false);
-        async Task<ExchangeWebResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
+        GetBookTickerOptions IBookTickerRestClient.GetBookTickerOptions { get; } = new GetBookTickerOptions(_exchangeName, false);
+        async Task<HttpResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((IBookTickerRestClient)this).GetBookTickerOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetBookTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedBookTicker>(Exchange, validationError);
+                return HttpResult.Fail<SharedBookTicker>(Exchange, validationError);
 
             var resultTicker = await ExchangeData.GetOrderBookAsync(request.Symbol!.GetSymbol(FormatSymbol), 5, ct: ct).ConfigureAwait(false);
-            if (!resultTicker)
-                return resultTicker.AsExchangeResult<SharedBookTicker>(Exchange, null, default);
+            if (!resultTicker.Success)
+                return HttpResult.Fail<SharedBookTicker>(resultTicker);
 
-            return resultTicker.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedBookTicker(
+            return HttpResult.Ok(resultTicker, new SharedBookTicker(
                 ExchangeSymbolCache.ParseSymbol(_topicId, resultTicker.Data.Symbol),
                 resultTicker.Data.Symbol,
                 resultTicker.Data.Data.Asks[0].Price,
@@ -229,23 +224,23 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
         #region Recent Trades
 
-        GetRecentTradesOptions IRecentTradeRestClient.GetRecentTradesOptions { get; } = new GetRecentTradesOptions(1000, false);
+        GetRecentTradesOptions IRecentTradeRestClient.GetRecentTradesOptions { get; } = new GetRecentTradesOptions(_exchangeName, 1000, false);
 
-        async Task<ExchangeWebResult<SharedTrade[]>> IRecentTradeRestClient.GetRecentTradesAsync(GetRecentTradesRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedTrade[]>> IRecentTradeRestClient.GetRecentTradesAsync(GetRecentTradesRequest request, CancellationToken ct)
         {
-            var validationError = ((IRecentTradeRestClient)this).GetRecentTradesOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetRecentTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedTrade[]>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.GetTradeHistoryAsync(
                 symbol,
                 limit: request.Limit,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedTrade[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedTrade[]>(result);
 
-            return result.AsExchangeResult<SharedTrade[]>(Exchange, request.Symbol!.TradingMode, result.Data.Select(x => 
+            return HttpResult.Ok(result, result.Data.Select(x => 
             new SharedTrade(request.Symbol, symbol, x.Quantity, x.Price, x.Timestamp)
             {
                 Side = x.Side == OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell
@@ -255,27 +250,27 @@ namespace CoinEx.Net.Clients.SpotApiV2
         #endregion
 
         #region Balance client
-        GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(AccountTypeFilter.Spot, AccountTypeFilter.Margin);
+        GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(_exchangeName, AccountTypeFilter.Spot, AccountTypeFilter.Margin);
 
-        async Task<ExchangeWebResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
         {
-            var validationError = ((IBalanceRestClient)this).GetBalancesOptions.ValidateRequest(Exchange, request, SupportedTradingModes);
+            var validationError = SharedClient.GetBalancesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedBalance[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedBalance[]>(Exchange, validationError);
 
             if (request.AccountType == SharedAccountType.Spot || request.AccountType == null)
             {
                 var result = await Account.GetBalancesAsync(ct: ct).ConfigureAwait(false);
-                if (!result)
-                    return result.AsExchangeResult<SharedBalance[]>(Exchange, null, default);
+                if (!result.Success)
+                return HttpResult.Fail<SharedBalance[]>(result);
 
-                return result.AsExchangeResult<SharedBalance[]>(Exchange, TradingMode.Spot, result.Data.Select(x => new SharedBalance(x.Asset, x.Available, x.Available + x.Frozen)).ToArray());
+                return HttpResult.Ok(result, result.Data.Select(x => new SharedBalance(x.Asset, x.Available, x.Available + x.Frozen)).ToArray());
             }
             else
             {
                 var result = await Account.GetMarginBalancesAsync(ct: ct).ConfigureAwait(false);
-                if (!result)
-                    return result.AsExchangeResult<SharedBalance[]>(Exchange, null, default);
+                if (!result.Success)
+                return HttpResult.Fail<SharedBalance[]>(result);
 
                 var resultList = new List<SharedBalance>();
                 foreach(var item in result.Data)
@@ -284,7 +279,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
                     resultList.Add(new SharedBalance(item.QuoteAsset, item.Available.QuoteAsset, item.Available.QuoteAsset + item.Frozen.QuoteAsset) { IsolatedMarginSymbol = item.MarginAccount });
                 }
 
-                return result.AsExchangeResult<SharedBalance[]>(Exchange, TradingMode.Spot, resultList.ToArray());
+                return HttpResult.Ok(result, resultList.ToArray());
             }
         }
 
@@ -292,7 +287,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
         #region Spot Order client
 
-        PlaceSpotOrderOptions ISpotOrderRestClient.PlaceSpotOrderOptions { get; } = new PlaceSpotOrderOptions();
+        PlaceSpotOrderOptions ISpotOrderRestClient.PlaceSpotOrderOptions { get; } = new PlaceSpotOrderOptions(_exchangeName);
 
         SharedFeeDeductionType ISpotOrderRestClient.SpotFeeDeductionType => SharedFeeDeductionType.DeductFromOutput;
         SharedFeeAssetType ISpotOrderRestClient.SpotFeeAssetType => SharedFeeAssetType.OutputAsset;
@@ -307,18 +302,11 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
         string ISpotOrderRestClient.GenerateClientOrderId() => ExchangeHelpers.RandomString(20);
 
-        async Task<ExchangeWebResult<SharedId>> ISpotOrderRestClient.PlaceSpotOrderAsync(PlaceSpotOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> ISpotOrderRestClient.PlaceSpotOrderAsync(PlaceSpotOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).PlaceSpotOrderOptions.ValidateRequest(
-                Exchange,
-                request,
-                request.Symbol!.TradingMode,
-                SupportedTradingModes,
-                ((ISpotOrderRestClient)this).SpotSupportedOrderTypes,
-                ((ISpotOrderRestClient)this).SpotSupportedTimeInForce,
-                ((ISpotOrderRestClient)this).SpotSupportedOrderQuantity);
+            var validationError = SharedClient.PlaceSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await Trading.PlaceOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -332,27 +320,27 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 ct: ct
                 ).ConfigureAwait(false);
 
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedId(result.Data.Id.ToString()));
+            return HttpResult.Ok(result, new SharedId(result.Data.Id.ToString()));
         }
 
-        EndpointOptions<GetOrderRequest> ISpotOrderRestClient.GetSpotOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedSpotOrder>> ISpotOrderRestClient.GetSpotOrderAsync(GetOrderRequest request, CancellationToken ct)
+        GetSpotOrderOptions ISpotOrderRestClient.GetSpotOrderOptions { get; } = new GetSpotOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedSpotOrder>> ISpotOrderRestClient.GetSpotOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotOrder>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedSpotOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedSpotOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
 
             var orders = await Trading.GetOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedSpotOrder>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedSpotOrder>(orders);
 
-            return orders.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotOrder(
+            return HttpResult.Ok(orders, new SharedSpotOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicId, orders.Data.Symbol),
                 orders.Data.Symbol,
                 orders.Data.Id.ToString(),
@@ -372,20 +360,20 @@ namespace CoinEx.Net.Clients.SpotApiV2
             });
         }
 
-        EndpointOptions<GetOpenOrdersRequest> ISpotOrderRestClient.GetOpenSpotOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest>(true);
-        async Task<ExchangeWebResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetOpenSpotOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
+        GetOpenSpotOrdersOptions ISpotOrderRestClient.GetOpenSpotOrdersOptions { get; } = new GetOpenSpotOrdersOptions(_exchangeName, true);
+        async Task<HttpResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetOpenSpotOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetOpenSpotOrdersOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetOpenSpotOrdersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotOrder[]>(Exchange, validationError);
 
             string? symbol = request.Symbol?.GetSymbol(FormatSymbol);
 
             var orders = await Trading.GetOpenOrdersAsync(AccountType.Spot, symbol, ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedSpotOrder[]>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedSpotOrder[]>(orders);
 
-            return orders.AsExchangeResult<SharedSpotOrder[]>(Exchange, TradingMode.Spot, orders.Data.Items.Select(x => new SharedSpotOrder(
+            return HttpResult.Ok(orders, orders.Data.Items.Select(x => new SharedSpotOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
                 x.Symbol,
                 x.Id.ToString(),
@@ -405,12 +393,12 @@ namespace CoinEx.Net.Clients.SpotApiV2
             }).ToArray());
         }
 
-        GetClosedOrdersOptions ISpotOrderRestClient.GetClosedSpotOrdersOptions { get; } = new GetClosedOrdersOptions(false, true, false, 500);
-        async Task<ExchangeWebResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetClosedSpotOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetSpotClosedOrdersOptions ISpotOrderRestClient.GetClosedSpotOrdersOptions { get; } = new GetSpotClosedOrdersOptions(_exchangeName, false, true, false, 500);
+        async Task<HttpResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetClosedSpotOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetClosedSpotOrdersOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetClosedSpotOrdersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotOrder[]>(Exchange, validationError);
 
             // Determine page token
             var direction = DataDirection.Descending;
@@ -425,8 +413,8 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 page: pageParams.Page,
                 pageSize: limit,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotOrder[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotOrder[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                     () => Pagination.NextPageFromPage(pageParams),
@@ -436,10 +424,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
                     request.EndTime ?? DateTime.UtcNow,
                     pageParams);
 
-            return result.AsExchangeResult(
-                    Exchange,
-                    TradingMode.Spot,
-                    ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                     .Select(x => new SharedSpotOrder(
                         ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
                         x.Symbol,
@@ -461,21 +446,21 @@ namespace CoinEx.Net.Clients.SpotApiV2
                     .ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<GetOrderTradesRequest> ISpotOrderRestClient.GetSpotOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest>(true);
-        async Task<ExchangeWebResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
+        GetSpotOrderTradesOptions ISpotOrderRestClient.GetSpotOrderTradesOptions { get; } = new GetSpotOrderTradesOptions(_exchangeName, true);
+        async Task<HttpResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotOrderTradesOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotOrderTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest.OrderId), "Invalid order id"));
 
             var orders = await Trading.GetOrderTradesAsync(request.Symbol!.GetSymbol(FormatSymbol), AccountType.Spot, orderId: orderId, ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(orders);
 
-            return orders.AsExchangeResult<SharedUserTrade[]>(Exchange, request.Symbol!.TradingMode,orders.Data.Items.Select(x => new SharedUserTrade(
+            return HttpResult.Ok(orders, orders.Data.Items.Select(x => new SharedUserTrade(
                 ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString(),
@@ -492,12 +477,12 @@ namespace CoinEx.Net.Clients.SpotApiV2
             }).ToArray());
         }
 
-        GetUserTradesOptions ISpotOrderRestClient.GetSpotUserTradesOptions { get; } = new GetUserTradesOptions(false, true, true, 500);
-        async Task<ExchangeWebResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetSpotUserTradesOptions ISpotOrderRestClient.GetSpotUserTradesOptions { get; } = new GetSpotUserTradesOptions(_exchangeName, false, true, true, 500);
+        async Task<HttpResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotUserTradesOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotUserTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             // Determine page token
             int limit = request.Limit ?? 500;
@@ -513,8 +498,8 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 page: pageParams.Page,
                 pageSize: limit,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                     () => Pagination.NextPageFromPage(pageParams),
@@ -524,10 +509,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
                     request.EndTime ?? DateTime.UtcNow,
                     pageParams);
 
-            return result.AsExchangeResult(
-                    Exchange,
-                    TradingMode.Spot,
-                    ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                     .Select(x => new SharedUserTrade(
                         ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), 
                         x.Symbol,
@@ -546,21 +528,21 @@ namespace CoinEx.Net.Clients.SpotApiV2
                     .ToArray(), nextPageRequest);
         }
                 
-        EndpointOptions<CancelOrderRequest> ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> ISpotOrderRestClient.CancelSpotOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelSpotOrderOptions ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new CancelSpotOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> ISpotOrderRestClient.CancelSpotOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).CancelSpotOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
+                return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest.OrderId), "Invalid order id"));
 
             var order = await Trading.CancelOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), AccountType.Spot, orderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedId(order.Data.Id.ToString()));
+            return HttpResult.Ok(order, new SharedId(order.Data.Id.ToString()));
         }
 
         private SharedOrderStatus ParseOrderStatus(OrderStatusV2? status)
@@ -599,31 +581,31 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
         #region Spot Client Id Order Client
 
-        EndpointOptions<GetOrderRequest> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedSpotOrder>> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
+        GetSpotOrderByClientOrderIdOptions ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdOptions { get; } = new GetSpotOrderByClientOrderIdOptions(_exchangeName, true);
+        async Task<HttpResult<SharedSpotOrder>> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotOrder>(Exchange, validationError);
 
             var order = await Trading.GetOpenOrdersAsync(AccountType.Spot, clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedSpotOrder>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedSpotOrder>(order);
 
             var orderData = order.Data.Items.FirstOrDefault();
             if (orderData == null)
             {
                 order = await Trading.GetClosedOrdersAsync(AccountType.Spot, clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-                if (!order)
-                    return order.AsExchangeResult<SharedSpotOrder>(Exchange, null, default);
+                if (!order.Success)
+                return HttpResult.Fail<SharedSpotOrder>(order);
 
                 orderData = order.Data.Items.FirstOrDefault();                
             }
 
             if (orderData == null)
-                return new ExchangeWebResult<SharedSpotOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
+                return HttpResult.Fail<SharedSpotOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
-            return order.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotOrder(
+            return HttpResult.Ok(order, new SharedSpotOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicId, orderData.Symbol),
                 orderData.Symbol,
                 orderData.Id.ToString(),
@@ -643,35 +625,35 @@ namespace CoinEx.Net.Clients.SpotApiV2
             });
         }
 
-        EndpointOptions<CancelOrderRequest> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelSpotOrderByClientOrderIdOptions ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdOptions { get; } = new CancelSpotOrderByClientOrderIdOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).CancelSpotOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var order = await Trading.CancelOrdersByClientOrderIdAsync(request.Symbol!.GetSymbol(FormatSymbol), AccountType.Spot, clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(order.Data.FirstOrDefault()?.Id.ToString() ?? request.OrderId));
+            return HttpResult.Ok(order, new SharedId(order.Data.FirstOrDefault()?.Id.ToString() ?? request.OrderId));
         }
         #endregion
 
         #region Asset client
 
-        EndpointOptions<GetAssetRequest> IAssetsRestClient.GetAssetOptions { get; } = new EndpointOptions<GetAssetRequest>(false);
-        async Task<ExchangeWebResult<SharedAsset>> IAssetsRestClient.GetAssetAsync(GetAssetRequest request, CancellationToken ct)
+        GetAssetOptions IAssetsRestClient.GetAssetOptions { get; } = new GetAssetOptions(_exchangeName, false);
+        async Task<HttpResult<SharedAsset>> IAssetsRestClient.GetAssetAsync(GetAssetRequest request, CancellationToken ct)
         {
-            var validationError = ((IAssetsRestClient)this).GetAssetOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetAssetOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedAsset>(Exchange, validationError);
+                return HttpResult.Fail<SharedAsset>(Exchange, validationError);
 
             var asset = await Account.GetDepositWithdrawalConfigAsync(request.Asset, ct: ct).ConfigureAwait(false);
-            if (!asset)
-                return asset.AsExchangeResult<SharedAsset>(Exchange, null, default);
+            if (!asset.Success)
+                return HttpResult.Fail<SharedAsset>(asset);
 
-            return asset.AsExchangeResult(Exchange, TradingMode.Spot, new SharedAsset(asset.Data.Asset.Asset)
+            return HttpResult.Ok(asset, new SharedAsset(asset.Data.Asset.Asset)
             {
                 Networks = asset.Data.Networks.Select(x => new SharedAssetNetwork(x.Network)
                 {
@@ -684,22 +666,22 @@ namespace CoinEx.Net.Clients.SpotApiV2
             });
         }
 
-        EndpointOptions<GetAssetsRequest> IAssetsRestClient.GetAssetsOptions { get; } = new EndpointOptions<GetAssetsRequest>(false);
-        async Task<ExchangeWebResult<SharedAsset[]>> IAssetsRestClient.GetAssetsAsync(GetAssetsRequest request, CancellationToken ct)
+        GetAssetsOptions IAssetsRestClient.GetAssetsOptions { get; } = new GetAssetsOptions(_exchangeName, false);
+        async Task<HttpResult<SharedAsset[]>> IAssetsRestClient.GetAssetsAsync(GetAssetsRequest request, CancellationToken ct)
         {
-            var validationError = ((IAssetsRestClient)this).GetAssetsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetAssetsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedAsset[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedAsset[]>(Exchange, validationError);
 
             var assets = ExchangeData.GetAssetsAsync(ct: ct);
             var assetConfigs = Account.GetAllDepositWithdrawalConfigsAsync(ct: ct);
             await Task.WhenAll(assets, assetConfigs).ConfigureAwait(false);
-            if (!assets.Result)
-                return assets.Result.AsExchangeResult<SharedAsset[]>(Exchange, null, default);
-            if (!assetConfigs.Result)
-                return assetConfigs.Result.AsExchangeResult<SharedAsset[]>(Exchange, null, default);
+            if (!assets.Result.Success)
+                return HttpResult.Fail<SharedAsset[]>(assets.Result);
+            if (!assetConfigs.Result.Success)
+                return HttpResult.Fail<SharedAsset[]>(assetConfigs.Result);
 
-            return assets.Result.AsExchangeResult<SharedAsset[]>(Exchange, TradingMode.Spot, assets.Result.Data.Select(x =>
+            return HttpResult.Ok(assets.Result, assets.Result.Data.Select(x =>
             {
                 var config = assetConfigs.Result.Data.SingleOrDefault(y => y.Asset.Asset.Equals(x.ShortName));
                 return new SharedAsset(x.ShortName)
@@ -720,7 +702,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
         #endregion
 
         #region Deposit client
-        EndpointOptions<GetDepositAddressesRequest> IDepositRestClient.GetDepositAddressesOptions { get; } = new EndpointOptions<GetDepositAddressesRequest>(true)
+        GetDepositAddressesOptions IDepositRestClient.GetDepositAddressesOptions { get; } = new GetDepositAddressesOptions(_exchangeName, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -728,17 +710,17 @@ namespace CoinEx.Net.Clients.SpotApiV2
             }
         };
 
-        async Task<ExchangeWebResult<SharedDepositAddress[]>> IDepositRestClient.GetDepositAddressesAsync(GetDepositAddressesRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedDepositAddress[]>> IDepositRestClient.GetDepositAddressesAsync(GetDepositAddressesRequest request, CancellationToken ct)
         {
-            var validationError = ((IDepositRestClient)this).GetDepositAddressesOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetDepositAddressesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedDepositAddress[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedDepositAddress[]>(Exchange, validationError);
 
             var depositAddresses = await Account.GetDepositAddressAsync(request.Asset, request.Network!).ConfigureAwait(false);
-            if (!depositAddresses)
-                return depositAddresses.AsExchangeResult<SharedDepositAddress[]>(Exchange, null, default);
+            if (!depositAddresses.Success)
+                return HttpResult.Fail<SharedDepositAddress[]>(depositAddresses);
 
-            return depositAddresses.AsExchangeResult<SharedDepositAddress[]>(Exchange, TradingMode.Spot, new[] { new SharedDepositAddress(request.Asset, depositAddresses.Data.Address)
+            return HttpResult.Ok(depositAddresses, new[] { new SharedDepositAddress(request.Asset, depositAddresses.Data.Address)
             {
                 Network = request.Network,
                 TagOrMemo = depositAddresses.Data.Memo
@@ -746,18 +728,18 @@ namespace CoinEx.Net.Clients.SpotApiV2
             });
         }
 
-        GetDepositsOptions IDepositRestClient.GetDepositsOptions { get; } = new GetDepositsOptions(false, true, false, 100)
+        GetDepositsOptions IDepositRestClient.GetDepositsOptions { get; } = new GetDepositsOptions(_exchangeName, false, true, false, 100)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
                 new ParameterDescription(nameof(GetWithdrawalsRequest.Asset), typeof(string), "Asset the deposits should be retrieved for", "ETH")
             }
         };
-        async Task<ExchangeWebResult<SharedDeposit[]>> IDepositRestClient.GetDepositsAsync(GetDepositsRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedDeposit[]>> IDepositRestClient.GetDepositsAsync(GetDepositsRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IDepositRestClient)this).GetDepositsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetDepositsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedDeposit[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedDeposit[]>(Exchange, validationError);
 
             // Determine page token
             int limit = request.Limit ?? 100;
@@ -770,8 +752,8 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 pageSize: limit,
                 page: pageParams.Page,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedDeposit[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedDeposit[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                     () => Pagination.NextPageFromPage(pageParams),
@@ -781,10 +763,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
                     request.EndTime ?? DateTime.UtcNow,
                     pageParams);
 
-            return result.AsExchangeResult(
-                    Exchange,
-                    TradingMode.Spot,
-                    ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                     .Select(x => 
                         new SharedDeposit(
                             x.Asset,
@@ -816,32 +795,32 @@ namespace CoinEx.Net.Clients.SpotApiV2
         #endregion
 
         #region Order Book client
-        GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions(new [] { 5, 10, 20, 50 }, false);
-        async Task<ExchangeWebResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
+        GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions(_exchangeName, new [] { 5, 10, 20, 50 }, false);
+        async Task<HttpResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
         {
-            var validationError = ((IOrderBookRestClient)this).GetOrderBookOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetOrderBookOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedOrderBook>(Exchange, validationError);
+                return HttpResult.Fail<SharedOrderBook>(Exchange, validationError);
 
             var result = await ExchangeData.GetOrderBookAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
                 limit: request.Limit ?? 20,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedOrderBook>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedOrderBook>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol!.TradingMode, new SharedOrderBook(result.Data.Data.Asks, result.Data.Data.Bids));
+            return HttpResult.Ok(result, new SharedOrderBook(result.Data.Data.Asks, result.Data.Data.Bids));
         }
         #endregion
 
         #region Withdrawal client
 
-        GetWithdrawalsOptions IWithdrawalRestClient.GetWithdrawalsOptions { get; } = new GetWithdrawalsOptions(false, true, false, 100);
-        async Task<ExchangeWebResult<SharedWithdrawal[]>> IWithdrawalRestClient.GetWithdrawalsAsync(GetWithdrawalsRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetWithdrawalsOptions IWithdrawalRestClient.GetWithdrawalsOptions { get; } = new GetWithdrawalsOptions(_exchangeName, false, true, false, 100);
+        async Task<HttpResult<SharedWithdrawal[]>> IWithdrawalRestClient.GetWithdrawalsAsync(GetWithdrawalsRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IWithdrawalRestClient)this).GetWithdrawalsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetWithdrawalsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedWithdrawal[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedWithdrawal[]>(Exchange, validationError);
 
             // Determine page token
             int limit = request.Limit ?? 100;
@@ -854,8 +833,8 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 pageSize: limit,
                 page: pageParams.Page,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedWithdrawal[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedWithdrawal[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                     () => Pagination.NextPageFromPage(pageParams),
@@ -865,10 +844,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
                     request.EndTime ?? DateTime.UtcNow,
                     pageParams);
 
-            return result.AsExchangeResult(
-                    Exchange,
-                    TradingMode.Spot,
-                    ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                     .Select(x => 
                         new SharedWithdrawal(x.Asset, x.ToAddress, x.Quantity, x.Status == WithdrawStatusV2.Finished, x.CreateTime)
                         {
@@ -886,13 +862,13 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
         #region Withdraw client
 
-        WithdrawOptions IWithdrawRestClient.WithdrawOptions { get; } = new WithdrawOptions();
+        WithdrawOptions IWithdrawRestClient.WithdrawOptions { get; } = new WithdrawOptions(_exchangeName);
 
-        async Task<ExchangeWebResult<SharedId>> IWithdrawRestClient.WithdrawAsync(WithdrawRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IWithdrawRestClient.WithdrawAsync(WithdrawRequest request, CancellationToken ct)
         {
-            var validationError = ((IWithdrawRestClient)this).WithdrawOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.WithdrawOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             // Get data
             var withdrawal = await Account.WithdrawAsync(
@@ -903,41 +879,41 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 method: MovementMethod.OnChain,
                 memo: request.AddressTag,
                 ct: ct).ConfigureAwait(false);
-            if (!withdrawal)
-                return withdrawal.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!withdrawal.Success)
+                return HttpResult.Fail<SharedId>(withdrawal);
 
-            return withdrawal.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(withdrawal.Data.Id.ToString()));
+            return HttpResult.Ok(withdrawal, new SharedId(withdrawal.Data.Id.ToString()));
         }
 
         #endregion
 
         #region Fee Client
-        EndpointOptions<GetFeeRequest> IFeeRestClient.GetFeeOptions { get; } = new EndpointOptions<GetFeeRequest>(true);
+        GetFeeOptions IFeeRestClient.GetFeeOptions { get; } = new GetFeeOptions(_exchangeName, true);
 
-        async Task<ExchangeWebResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
         {
-            var validationError = ((IFeeRestClient)this).GetFeeOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFeeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFee>(Exchange, validationError);
+                return HttpResult.Fail<SharedFee>(Exchange, validationError);
 
             // Get data
             var result = await Account.GetTradingFeesAsync(request.Symbol!.GetSymbol(FormatSymbol), AccountType.Spot, ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFee>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFee>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, TradingMode.Spot, new SharedFee(result.Data.MakerFeeRate * 100, result.Data.TakerFeeRate * 100));
+            return HttpResult.Ok(result, new SharedFee(result.Data.MakerFeeRate * 100, result.Data.TakerFeeRate * 100));
         }
         #endregion
 
         #region Spot Trigger Order Client
-        PlaceSpotTriggerOrderOptions ISpotTriggerOrderRestClient.PlaceSpotTriggerOrderOptions { get; } = new PlaceSpotTriggerOrderOptions(false);
+        PlaceSpotTriggerOrderOptions ISpotTriggerOrderRestClient.PlaceSpotTriggerOrderOptions { get; } = new PlaceSpotTriggerOrderOptions(_exchangeName, false);
 
-        async Task<ExchangeWebResult<SharedId>> ISpotTriggerOrderRestClient.PlaceSpotTriggerOrderAsync(PlaceSpotTriggerOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> ISpotTriggerOrderRestClient.PlaceSpotTriggerOrderAsync(PlaceSpotTriggerOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTriggerOrderRestClient)this).PlaceSpotTriggerOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes, ((ISpotOrderRestClient)this).SpotSupportedOrderQuantity);
+            var validationError = SharedClient.PlaceSpotTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var clientOrderId = request.ClientOrderId ?? ExchangeHelpers.RandomString(32);
             var result = await Trading.PlaceStopOrderAsync(
@@ -951,27 +927,27 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 quantityAsset: request.OrderPrice == null ? (request.Quantity != null ? request.Symbol!.BaseAsset : request.Symbol!.QuoteAsset) : null,
                 clientOrderId: clientOrderId,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(clientOrderId));
+            return HttpResult.Ok(result, new SharedId(clientOrderId));
         }
 
-        EndpointOptions<GetOrderRequest> ISpotTriggerOrderRestClient.GetSpotTriggerOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true)
+        GetSpotTriggerOrderOptions ISpotTriggerOrderRestClient.GetSpotTriggerOrderOptions { get; } = new GetSpotTriggerOrderOptions(_exchangeName, true)
         {
             RequestNotes = "Only pending trigger orders can be requested, executed trigger orders are not available in the API"
         };
-        async Task<ExchangeWebResult<SharedSpotTriggerOrder>> ISpotTriggerOrderRestClient.GetSpotTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedSpotTriggerOrder>> ISpotTriggerOrderRestClient.GetSpotTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTriggerOrderRestClient)this).GetSpotTriggerOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotTriggerOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotTriggerOrder>(Exchange, validationError);
 
             var status = SharedTriggerOrderStatus.Active;
             var orders = await Trading.GetOpenStopOrdersAsync(AccountType.Spot, clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!orders)
-                return orders.AsExchangeResult<SharedSpotTriggerOrder>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedSpotTriggerOrder>(orders);
 
             CoinExStopOrder order;
             if (orders.Data.Items.Any())
@@ -981,17 +957,17 @@ namespace CoinEx.Net.Clients.SpotApiV2
             else
             {
                 orders = await Trading.GetClosedStopOrdersAsync(AccountType.Spot, request.Symbol!.GetSymbol(FormatSymbol), pageSize: 1000, ct: ct).ConfigureAwait(false);
-                if (!orders)
-                    return orders.AsExchangeResult<SharedSpotTriggerOrder>(Exchange, null, default);
+                if (!orders.Success)
+                return HttpResult.Fail<SharedSpotTriggerOrder>(orders);
 
                 order = orders.Data.Items.SingleOrDefault(x => x.ClientOrderId == request.OrderId)!;
                 if (order == null)
-                    return orders.AsExchangeError<SharedSpotTriggerOrder>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
+                    return HttpResult.Fail<SharedSpotTriggerOrder>(orders, new ServerError(new ErrorInfo(ErrorType.UnknownOrder, "Order not found")));
 
                 status = SharedTriggerOrderStatus.Filled;
             }
 
-            return orders.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotTriggerOrder(
+            return HttpResult.Ok(orders, new SharedSpotTriggerOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicId, order.Symbol),
                 order.Symbol,
                 order.ClientOrderId?.ToString() ?? order.StopOrderId.ToString(),
@@ -1008,29 +984,29 @@ namespace CoinEx.Net.Clients.SpotApiV2
             });
         }
 
-        EndpointOptions<CancelOrderRequest> ISpotTriggerOrderRestClient.CancelSpotTriggerOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> ISpotTriggerOrderRestClient.CancelSpotTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelSpotTriggerOrderOptions ISpotTriggerOrderRestClient.CancelSpotTriggerOrderOptions { get; } = new CancelSpotTriggerOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> ISpotTriggerOrderRestClient.CancelSpotTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTriggerOrderRestClient)this).CancelSpotTriggerOrderOptions.ValidateRequest(Exchange, request, request.Symbol!.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelSpotTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var order = await Trading.CancelStopOrdersByClientOrderIdAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
                 AccountType.Spot,
                 request.OrderId,
                 ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(request.OrderId));
+            return HttpResult.Ok(order, new SharedId(request.OrderId));
         }
 
         #endregion
 
         #region Transfer client
 
-        TransferOptions ITransferRestClient.TransferOptions { get; } = new TransferOptions([
+        TransferOptions ITransferRestClient.TransferOptions { get; } = new TransferOptions(_exchangeName, [
             SharedAccountType.Spot,
             SharedAccountType.PerpetualLinearFutures,
             SharedAccountType.PerpetualInverseFutures,
@@ -1038,16 +1014,16 @@ namespace CoinEx.Net.Clients.SpotApiV2
             SharedAccountType.DeliveryInverseFutures,
             SharedAccountType.CrossMargin,
             SharedAccountType.IsolatedMargin]);
-        async Task<ExchangeWebResult<SharedId>> ITransferRestClient.TransferAsync(TransferRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> ITransferRestClient.TransferAsync(TransferRequest request, CancellationToken ct)
         {
-            var validationError = ((ITransferRestClient)this).TransferOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.TransferOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var fromType = GetTransferType(request.FromAccountType);
             var toType = GetTransferType(request.ToAccountType);
             if (fromType == null || toType == null)
-                return new ExchangeWebResult<SharedId>(Exchange, ArgumentError.Invalid("To/From AccountType", "invalid to/from account combination"));
+                return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid("To/From AccountType", "invalid to/from account combination"));
 
             // Get data
             var transfer = await Account.TransferAsync(
@@ -1057,10 +1033,10 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 request.Quantity,
                 fromType == AccountType.Margin ? request.FromSymbol : request.ToSymbol,
                 ct: ct).ConfigureAwait(false);
-            if (!transfer)
-                return transfer.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!transfer.Success)
+                return HttpResult.Fail<SharedId>(transfer);
 
-            return transfer.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(""));
+            return HttpResult.Ok(transfer, new SharedId(""));
         }
 
         private AccountType? GetTransferType(SharedAccountType type)

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiShared.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiShared.cs
@@ -846,7 +846,13 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data.Items, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                     .Select(x => 
-                        new SharedWithdrawal(x.Asset, x.ToAddress, x.Quantity, x.Status == WithdrawStatusV2.Finished, x.CreateTime)
+                        new SharedWithdrawal(
+                            x.Asset,
+                            x.ToAddress,
+                            x.Quantity,
+                            x.Status == WithdrawStatusV2.Finished,
+                            x.CreateTime,
+                            GetWithdrawalStatus(x))
                         {
                             Id = x.Id.ToString(),
                             Confirmations = x.Confirmations,
@@ -858,6 +864,25 @@ namespace CoinEx.Net.Clients.SpotApiV2
                     .ToArray(), nextPageRequest);
         }
 
+        private SharedTransferStatus GetWithdrawalStatus(CoinExWithdrawal x)
+        {
+            if (x.Status == WithdrawStatusV2.Canceled || x.Status == WithdrawStatusV2.Failed)
+                return SharedTransferStatus.Failed;
+
+            if (x.Status == WithdrawStatusV2.Finished)
+                return SharedTransferStatus.Completed;
+
+            if (x.Status == WithdrawStatusV2.Audited
+                || x.Status == WithdrawStatusV2.AuditRequired
+                || x.Status == WithdrawStatusV2.Confirming
+                || x.Status == WithdrawStatusV2.Processing
+                || x.Status == WithdrawStatusV2.Created)
+            {
+                return SharedTransferStatus.InProgress;
+            }
+
+            return SharedTransferStatus.Unknown;
+        }
         #endregion
 
         #region Withdraw client

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiTrading.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiTrading.cs
@@ -25,7 +25,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExOrder>> PlaceOrderAsync(
+        public async Task<HttpResult<CoinExOrder>> PlaceOrderAsync(
             string symbol, 
             AccountType accountType,
             OrderSide side,
@@ -44,26 +44,26 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 32,
                 _baseClient.ClientOptions.AllowAppendingClientOrderId);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddEnum("market_type", accountType);
-            parameters.AddEnum("side", side);
-            parameters.AddEnum("type", type);
-            parameters.AddString("amount", quantity);
-            parameters.AddOptionalString("price", price);
-            parameters.AddOptional("ccy", quantityAsset);
-            parameters.AddOptional("client_id", clientOrderId);
-            parameters.AddOptional("is_hide", hide);
-            parameters.AddOptionalEnum("stp_mode", stpMode);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/spot/order", CoinExExchange.RateLimiter.CoinExRestSpotOrder, 1, true);
+            parameters.Add("market_type", accountType);
+            parameters.Add("side", side);
+            parameters.Add("type", type);
+            parameters.Add("amount", quantity);
+            parameters.Add("price", price);
+            parameters.Add("ccy", quantityAsset);
+            parameters.Add("client_id", clientOrderId);
+            parameters.Add("is_hide", hide);
+            parameters.Add("stp_mode", stpMode);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/spot/order", CoinExExchange.RateLimiter.CoinExRestSpotOrder, 1, true);
             var result = await _baseClient.SendAsync<CoinExOrder>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExStopId>> PlaceStopOrderAsync(
+        public async Task<HttpResult<CoinExStopId>> PlaceStopOrderAsync(
             string symbol,
             AccountType accountType,
             OrderSide side,
@@ -83,27 +83,27 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 32,
                 _baseClient.ClientOptions.AllowAppendingClientOrderId);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddEnum("market_type", accountType);
-            parameters.AddEnum("side", side);
-            parameters.AddEnum("type", type);
-            parameters.AddString("amount", quantity);
-            parameters.AddString("trigger_price", triggerPrice);
-            parameters.AddOptionalString("price", price);
-            parameters.AddOptional("ccy", quantityAsset);
-            parameters.AddOptional("client_id", clientOrderId);
-            parameters.AddOptional("is_hide", hide);
-            parameters.AddOptionalEnum("stp_mode", stpMode);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/spot/stop-order", CoinExExchange.RateLimiter.CoinExRestSpotOrder, 1, true);
+            parameters.Add("market_type", accountType);
+            parameters.Add("side", side);
+            parameters.Add("type", type);
+            parameters.Add("amount", quantity);
+            parameters.Add("trigger_price", triggerPrice);
+            parameters.Add("price", price);
+            parameters.Add("ccy", quantityAsset);
+            parameters.Add("client_id", clientOrderId);
+            parameters.Add("is_hide", hide);
+            parameters.Add("stp_mode", stpMode);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/spot/stop-order", CoinExExchange.RateLimiter.CoinExRestSpotOrder, 1, true);
             var result = await _baseClient.SendAsync<CoinExStopId>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CallResult<CoinExBatchOrderResult>[]>> PlaceMultipleOrdersAsync(
+        public async Task<HttpResult<CallResult<CoinExBatchOrderResult>[]>> PlaceMultipleOrdersAsync(
             IEnumerable<CoinExPlaceOrderRequest> requests,
             CancellationToken ct = default)
         {
@@ -116,32 +116,32 @@ namespace CoinEx.Net.Clients.SpotApiV2
                     _baseClient.ClientOptions.AllowAppendingClientOrderId);
             }
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "orders", requests.ToArray() }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/spot/batch-order", CoinExExchange.RateLimiter.CoinExRestSpotOrder, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/spot/batch-order", CoinExExchange.RateLimiter.CoinExRestSpotOrder, 1, true);
             var resultData = await _baseClient.SendAsync<CoinExBatchResult<CoinExBatchOrderResult>[]>(request, parameters, ct, weight: requests.Count()).ConfigureAwait(false);
-            if (!resultData)
-                return resultData.As<CallResult<CoinExBatchOrderResult>[]>(default);
+            if (!resultData.Success)
+                return HttpResult.Fail<CallResult<CoinExBatchOrderResult>[]>(resultData);
 
             var result = new List<CallResult<CoinExBatchOrderResult>>();
             foreach (var item in resultData.Data!)
             {
                 if (item.Code != 0)
-                    result.Add(new CallResult<CoinExBatchOrderResult>(new ServerError(item.Code, _baseClient.GetErrorInfo(item.Code, item.Message!))));
+                    result.Add(CallResult<CoinExBatchOrderResult>.Fail(new ServerError(item.Code, _baseClient.GetErrorInfo(item.Code, item.Message!))));
                 else
-                    result.Add(new CallResult<CoinExBatchOrderResult>(item.Data!));
+                    result.Add(CallResult<CoinExBatchOrderResult>.Ok(item.Data!));
             }
 
             if (result.All(x => !x.Success))
-                return resultData.AsErrorWithData(new ServerError(new ErrorInfo (ErrorType.AllOrdersFailed, "All orders failed")), result.ToArray());
+                return HttpResult.Fail<CallResult<CoinExBatchOrderResult>[]>(resultData, new ServerError(new ErrorInfo (ErrorType.AllOrdersFailed, "All orders failed")), result.ToArray());
 
-            return resultData.As(result.ToArray());
+            return HttpResult.Ok(resultData, result.ToArray());
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CallResult<CoinExStopId>[]>> PlaceMultipleStopOrdersAsync(
+        public async Task<HttpResult<CallResult<CoinExStopId>[]>> PlaceMultipleStopOrdersAsync(
             IEnumerable<CoinExPlaceStopOrderRequest> requests,
             CancellationToken ct = default)
         {
@@ -154,74 +154,74 @@ namespace CoinEx.Net.Clients.SpotApiV2
                     _baseClient.ClientOptions.AllowAppendingClientOrderId);
             }
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "orders", requests.ToArray() }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/spot/batch-stop-order", CoinExExchange.RateLimiter.CoinExRestSpotOrder, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/spot/batch-stop-order", CoinExExchange.RateLimiter.CoinExRestSpotOrder, 1, true);
             var resultData = await _baseClient.SendAsync<CoinExBatchResult<CoinExStopId>[]>(request, parameters, ct, weight: requests.Count()).ConfigureAwait(false);
-            if (!resultData)
-                return resultData.As<CallResult<CoinExStopId>[]>(default);
+            if (!resultData.Success)
+                return HttpResult.Fail<CallResult<CoinExStopId>[]>(resultData);
 
             var result = new List<CallResult<CoinExStopId>>();
             foreach (var item in resultData.Data!)
             {
                 if (item.Code != 0)
-                    result.Add(new CallResult<CoinExStopId>(new ServerError(item.Code, _baseClient.GetErrorInfo(item.Code, item.Message!))));
+                    result.Add(CallResult<CoinExStopId>.Fail(new ServerError(item.Code, _baseClient.GetErrorInfo(item.Code, item.Message!))));
                 else
-                    result.Add(new CallResult<CoinExStopId>(item.Data!));
+                    result.Add(CallResult<CoinExStopId>.Ok(item.Data!));
             }
 
             if (result.All(x => !x.Success))
-                return resultData.AsErrorWithData(new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), result.ToArray());
+                return HttpResult.Fail<CallResult<CoinExStopId>[]>(resultData, new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), result.ToArray());
 
-            return resultData.As(result.ToArray());
+            return HttpResult.Ok(resultData, result.ToArray());
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExOrder>> GetOrderAsync(string symbol, long orderId, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExOrder>> GetOrderAsync(string symbol, long orderId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "order_id", orderId }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/spot/order-status", CoinExExchange.RateLimiter.CoinExRestSpotQuery, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/spot/order-status", CoinExExchange.RateLimiter.CoinExRestSpotQuery, 1, true);
             return await _baseClient.SendAsync<CoinExOrder>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExOrder>>> GetOpenOrdersAsync(AccountType accountType, string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExOrder>>> GetOpenOrdersAsync(AccountType accountType, string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddEnum("market_type", accountType);
-            parameters.AddOptionalEnum("side", side);
-            parameters.AddOptional("market", symbol);
-            parameters.AddOptional("client_id", clientOrderId);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market_type", accountType);
+            parameters.Add("side", side);
+            parameters.Add("market", symbol);
+            parameters.Add("client_id", clientOrderId);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/spot/pending-order", CoinExExchange.RateLimiter.CoinExRestSpotQuery, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/spot/pending-order", CoinExExchange.RateLimiter.CoinExRestSpotQuery, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExOrder>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExOrder>>> GetClosedOrdersAsync(AccountType accountType, string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExOrder>>> GetClosedOrdersAsync(AccountType accountType, string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddEnum("market_type", accountType);
-            parameters.AddOptionalEnum("side", side);
-            parameters.AddOptional("market", symbol);
-            parameters.AddOptional("client_id", clientOrderId);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market_type", accountType);
+            parameters.Add("side", side);
+            parameters.Add("market", symbol);
+            parameters.Add("client_id", clientOrderId);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/spot/finished-order", CoinExExchange.RateLimiter.CoinExRestSpotHistory, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/spot/finished-order", CoinExExchange.RateLimiter.CoinExRestSpotHistory, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExOrder>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExStopOrder>>> GetOpenStopOrdersAsync(AccountType accountType, string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExStopOrder>>> GetOpenStopOrdersAsync(AccountType accountType, string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
             if (clientOrderId != null)
             {
@@ -232,32 +232,32 @@ namespace CoinEx.Net.Clients.SpotApiV2
                     _baseClient.ClientOptions.AllowAppendingClientOrderId);
             }
 
-            var parameters = new ParameterCollection();
-            parameters.AddEnum("market_type", accountType);
-            parameters.AddOptionalEnum("side", side);
-            parameters.AddOptional("market", symbol);
-            parameters.AddOptional("client_id", clientOrderId);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/spot/pending-stop-order", CoinExExchange.RateLimiter.CoinExRestSpotQuery, 1, true);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market_type", accountType);
+            parameters.Add("side", side);
+            parameters.Add("market", symbol);
+            parameters.Add("client_id", clientOrderId);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/spot/pending-stop-order", CoinExExchange.RateLimiter.CoinExRestSpotQuery, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExStopOrder>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExStopOrder>>> GetClosedStopOrdersAsync(AccountType accountType, string? symbol = null, OrderSide? side = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExStopOrder>>> GetClosedStopOrdersAsync(AccountType accountType, string? symbol = null, OrderSide? side = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection();
-            parameters.AddEnum("market_type", accountType);
-            parameters.AddOptionalEnum("side", side);
-            parameters.AddOptional("market", symbol);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/spot/finished-stop-order", CoinExExchange.RateLimiter.CoinExRestSpotHistory, 1, true);
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings);
+            parameters.Add("market_type", accountType);
+            parameters.Add("side", side);
+            parameters.Add("market", symbol);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/spot/finished-stop-order", CoinExExchange.RateLimiter.CoinExRestSpotHistory, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExStopOrder>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExOrder>> EditOrderAsync(
+        public async Task<HttpResult<CoinExOrder>> EditOrderAsync(
             string symbol,
             AccountType accountType,
             long orderId,
@@ -265,20 +265,20 @@ namespace CoinEx.Net.Clients.SpotApiV2
             decimal? price = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "order_id", orderId }
             };
-            parameters.AddEnum("market_type", accountType);
-            parameters.AddString("amount", quantity);
-            parameters.AddOptionalString("price", price);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/spot/modify-order", CoinExExchange.RateLimiter.CoinExRestSpotOrder, 1, true);
+            parameters.Add("market_type", accountType);
+            parameters.Add("amount", quantity);
+            parameters.Add("price", price);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/spot/modify-order", CoinExExchange.RateLimiter.CoinExRestSpotOrder, 1, true);
             return await _baseClient.SendAsync<CoinExOrder>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExStopId>> EditStopOrderAsync(
+        public async Task<HttpResult<CoinExStopId>> EditStopOrderAsync(
             string symbol,
             AccountType accountType,
             long stopOrderId,
@@ -287,76 +287,76 @@ namespace CoinEx.Net.Clients.SpotApiV2
             decimal? price = null,
             CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "stop_id", stopOrderId }
             };
-            parameters.AddEnum("market_type", accountType);
-            parameters.AddString("amount", quantity);
-            parameters.AddString("trigger_price", triggerPrice);
-            parameters.AddOptionalString("price", price);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/spot/modify-stop-order", CoinExExchange.RateLimiter.CoinExRestSpotOrder, 1, true);
+            parameters.Add("market_type", accountType);
+            parameters.Add("amount", quantity);
+            parameters.Add("trigger_price", triggerPrice);
+            parameters.Add("price", price);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/spot/modify-stop-order", CoinExExchange.RateLimiter.CoinExRestSpotOrder, 1, true);
             return await _baseClient.SendAsync<CoinExStopId>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult> CancelAllOrdersAsync(string symbol, AccountType accountType, OrderSide? side = null, CancellationToken ct = default)
+        public async Task<HttpResult> CancelAllOrdersAsync(string symbol, AccountType accountType, OrderSide? side = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
             };
-            parameters.AddEnum("market_type", accountType);
-            parameters.AddOptionalEnum("side", side);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/spot/cancel-all-order", CoinExExchange.RateLimiter.CoinExRestSpotBatchCancel, 1, true);
+            parameters.Add("market_type", accountType);
+            parameters.Add("side", side);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/spot/cancel-all-order", CoinExExchange.RateLimiter.CoinExRestSpotBatchCancel, 1, true);
             return await _baseClient.SendAsync(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExOrder>> CancelOrderAsync(string symbol, AccountType accountType, long orderId, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExOrder>> CancelOrderAsync(string symbol, AccountType accountType, long orderId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "order_id", orderId }
             };
-            parameters.AddEnum("market_type", accountType);
+            parameters.Add("market_type", accountType);
 
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/spot/cancel-order", CoinExExchange.RateLimiter.CoinExRestSpotCancel, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/spot/cancel-order", CoinExExchange.RateLimiter.CoinExRestSpotCancel, 1, true);
             var result = await _baseClient.SendAsync<CoinExOrder>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExBatchResult<CoinExOrder>[]>> CancelOrdersAsync(string symbol, IEnumerable<long> orderIds, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExBatchResult<CoinExOrder>[]>> CancelOrdersAsync(string symbol, IEnumerable<long> orderIds, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "order_ids", orderIds.ToArray() }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/spot/cancel-batch-order", CoinExExchange.RateLimiter.CoinExRestSpotBatchCancel, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/spot/cancel-batch-order", CoinExExchange.RateLimiter.CoinExRestSpotBatchCancel, 1, true);
             var result = await _baseClient.SendAsync<CoinExBatchResult<CoinExOrder>[]>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExStopOrder>> CancelStopOrderAsync(string symbol, AccountType accountType, long stopOrderId, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExStopOrder>> CancelStopOrderAsync(string symbol, AccountType accountType, long stopOrderId, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "stop_id", stopOrderId }
             };
-            parameters.AddEnum("market_type", accountType);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/spot/cancel-stop-order", CoinExExchange.RateLimiter.CoinExRestSpotCancel, 1, true);
+            parameters.Add("market_type", accountType);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/spot/cancel-stop-order", CoinExExchange.RateLimiter.CoinExRestSpotCancel, 1, true);
             var result = await _baseClient.SendAsync<CoinExStopOrder>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExOrder[]>> CancelOrdersByClientOrderIdAsync(string symbol, AccountType accountType, string clientOrderId, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExOrder[]>> CancelOrdersByClientOrderIdAsync(string symbol, AccountType accountType, string clientOrderId, CancellationToken ct = default)
         {
             clientOrderId = LibraryHelpers.ApplyBrokerId(
                 clientOrderId,
@@ -364,19 +364,19 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 32,
                 _baseClient.ClientOptions.AllowAppendingClientOrderId);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "client_id", clientOrderId }
             };
-            parameters.AddEnum("market_type", accountType);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/spot/cancel-order-by-client-id", CoinExExchange.RateLimiter.CoinExRestSpotBatchCancel, 1, true);
+            parameters.Add("market_type", accountType);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/spot/cancel-order-by-client-id", CoinExExchange.RateLimiter.CoinExRestSpotBatchCancel, 1, true);
             var result = await _baseClient.SendAsync<CoinExOrder[]>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExStopOrder[]>> CancelStopOrdersByClientOrderIdAsync(string symbol, AccountType accountType, string clientStopOrderId, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExStopOrder[]>> CancelStopOrdersByClientOrderIdAsync(string symbol, AccountType accountType, string clientStopOrderId, CancellationToken ct = default)
         {
             clientStopOrderId = LibraryHelpers.ApplyBrokerId(
                 clientStopOrderId,
@@ -384,59 +384,59 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 32,
                 _baseClient.ClientOptions.AllowAppendingClientOrderId);
 
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "client_id", clientStopOrderId }
             };
-            parameters.AddEnum("market_type", accountType);
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/spot/cancel-stop-order-by-client-id", CoinExExchange.RateLimiter.CoinExRestSpotBatchCancel, 1, true);
+            parameters.Add("market_type", accountType);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/spot/cancel-stop-order-by-client-id", CoinExExchange.RateLimiter.CoinExRestSpotBatchCancel, 1, true);
             var result = await _baseClient.SendAsync<CoinExStopOrder[]>(request, parameters, ct).ConfigureAwait(false);
             return result;
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExBatchResult<CoinExStopOrder>[]>> CancelStopOrdersAsync(string symbol, IEnumerable<long> orderIds, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExBatchResult<CoinExStopOrder>[]>> CancelStopOrdersAsync(string symbol, IEnumerable<long> orderIds, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "stop_ids", orderIds.ToArray() }
             };
-            var request = _definitions.GetOrCreate(HttpMethod.Post, "v2/spot/cancel-batch-stop-order", CoinExExchange.RateLimiter.CoinExRestSpotBatchCancel, 1, true);
+            var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "v2/spot/cancel-batch-stop-order", CoinExExchange.RateLimiter.CoinExRestSpotBatchCancel, 1, true);
             var result = await _baseClient.SendAsync<CoinExBatchResult<CoinExStopOrder>[]>(request, parameters, ct, weight: orderIds.Count()).ConfigureAwait(false);
             return result;
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExUserTrade>>> GetUserTradesAsync(string symbol, AccountType accountType, OrderSide? side = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExUserTrade>>> GetUserTradesAsync(string symbol, AccountType accountType, OrderSide? side = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol }
             };
-            parameters.AddEnum("market_type", accountType);
-            parameters.AddOptionalEnum("side", side);
-            parameters.AddOptionalMilliseconds("start_time", startTime);
-            parameters.AddOptionalMilliseconds("end_Time", endTime);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/spot/user-deals", CoinExExchange.RateLimiter.CoinExRestSpotHistory, 1, true);
+            parameters.Add("market_type", accountType);
+            parameters.Add("side", side);
+            parameters.Add("start_time", startTime);
+            parameters.Add("end_Time", endTime);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/spot/user-deals", CoinExExchange.RateLimiter.CoinExRestSpotHistory, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExUserTrade>(request, parameters, ct).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<WebCallResult<CoinExPaginated<CoinExUserTrade>>> GetOrderTradesAsync(string symbol, AccountType accountType, long orderId, int? page = null, int? pageSize = null, CancellationToken ct = default)
+        public async Task<HttpResult<CoinExPaginated<CoinExUserTrade>>> GetOrderTradesAsync(string symbol, AccountType accountType, long orderId, int? page = null, int? pageSize = null, CancellationToken ct = default)
         {
-            var parameters = new ParameterCollection()
+            var parameters = new Parameters(CoinExExchange._parameterSerializationSettings)
             {
                 { "market", symbol },
                 { "order_id", orderId }
             };
-            parameters.AddEnum("market_type", accountType);
-            parameters.AddOptional("page", page);
-            parameters.AddOptional("limit", pageSize);
-            var request = _definitions.GetOrCreate(HttpMethod.Get, "v2/spot/order-deals", CoinExExchange.RateLimiter.CoinExRestSpotHistory, 1, true);
+            parameters.Add("market_type", accountType);
+            parameters.Add("page", page);
+            parameters.Add("limit", pageSize);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "v2/spot/order-deals", CoinExExchange.RateLimiter.CoinExRestSpotHistory, 1, true);
             return await _baseClient.SendPaginatedAsync<CoinExUserTrade>(request, parameters, ct).ConfigureAwait(false);
         }
     }

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExSocketClientSpotApi.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExSocketClientSpotApi.cs
@@ -44,7 +44,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
         /// Create a new instance of CoinExSocketClient with default options
         /// </summary>
         internal CoinExSocketClientSpotApi(ILogger logger, CoinExSocketOptions options)
-            : base(logger, options.Environment.SocketBaseAddress, options, options.SpotOptions)
+            : base(logger, CoinExExchange.Metadata.Id, options.Environment.SocketBaseAddress, options, options.SpotOptions)
         {
             KeepAliveInterval = TimeSpan.Zero; // Server doesn't correctly respond to ping frames
 
@@ -93,7 +93,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
         #region public
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToSystemNoticeUpdatesAsync(Action<DataEvent<CoinExMaintenance[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToSystemNoticeUpdatesAsync(Action<DataEvent<CoinExMaintenance[]>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, CoinExSocketUpdate<CoinExMaintenance[]>>((receiveTime, originalData, invocations, data) =>
             {
@@ -112,7 +112,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(Action<DataEvent<CoinExTicker[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(Action<DataEvent<CoinExTicker[]>> onMessage, CancellationToken ct = default)
         {
             var subscription = new CoinExTickerSubscription(_logger, this, [], new Dictionary<string, object>
             {
@@ -122,7 +122,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExTicker[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExTicker[]>> onMessage, CancellationToken ct = default)
         {
             var subscription = new CoinExTickerSubscription(_logger, this, symbols.ToArray(), new Dictionary<string, object>
             {
@@ -132,11 +132,11 @@ namespace CoinEx.Net.Clients.SpotApiV2
         }
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int depth, string? mergeLevel, bool fullBookUpdates, Action<DataEvent<CoinExOrderBook>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int depth, string? mergeLevel, bool fullBookUpdates, Action<DataEvent<CoinExOrderBook>> onMessage, CancellationToken ct = default)
             => SubscribeToOrderBookUpdatesAsync(new [] { symbol }, depth, mergeLevel, fullBookUpdates, onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, int depth, string? mergeLevel, bool fullBookUpdates, Action<DataEvent<CoinExOrderBook>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, int depth, string? mergeLevel, bool fullBookUpdates, Action<DataEvent<CoinExOrderBook>> onMessage, CancellationToken ct = default)
         {
             var subscription = new CoinExOrderBookSubscription(_logger, this, symbols.ToArray(), new Dictionary<string, object>
             {
@@ -146,15 +146,15 @@ namespace CoinEx.Net.Clients.SpotApiV2
         }
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default)
             => SubscribeToTradeUpdatesAsync(new[] { symbol }, onMessage, ct);
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default)
             => SubscribeToTradeUpdatesAsync(new string[] { }, onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default)
         {
             var subscription = new CoinExTradesSubscription(_logger, this, symbols.ToArray(), new Dictionary<string, object>
             {
@@ -164,11 +164,11 @@ namespace CoinEx.Net.Clients.SpotApiV2
         }
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToIndexPriceUpdatesAsync(string symbol, Action<DataEvent<CoinExIndexPriceUpdate>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToIndexPriceUpdatesAsync(string symbol, Action<DataEvent<CoinExIndexPriceUpdate>> onMessage, CancellationToken ct = default)
             => SubscribeToIndexPriceUpdatesAsync(new[] { symbol }, onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToIndexPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExIndexPriceUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToIndexPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExIndexPriceUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, CoinExSocketUpdate<CoinExIndexPriceUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -188,11 +188,11 @@ namespace CoinEx.Net.Clients.SpotApiV2
         }
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(string symbol, Action<DataEvent<CoinExBookPriceUpdate>> onMessage, CancellationToken ct = default)
+        public Task<WebSocketResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(string symbol, Action<DataEvent<CoinExBookPriceUpdate>> onMessage, CancellationToken ct = default)
             => SubscribeToBookPriceUpdatesAsync(new[] { symbol }, onMessage, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExBookPriceUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExBookPriceUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, CoinExSocketUpdate<CoinExBookPriceUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -215,7 +215,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(Action<DataEvent<CoinExOrderUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(Action<DataEvent<CoinExOrderUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, CoinExSocketUpdate<CoinExOrderUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -239,7 +239,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToStopOrderUpdatesAsync(Action<DataEvent<CoinExStopOrderUpdate>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToStopOrderUpdatesAsync(Action<DataEvent<CoinExStopOrderUpdate>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, CoinExSocketUpdate<CoinExStopOrderUpdate>>((receiveTime, originalData, invocations, data) =>
             {
@@ -262,7 +262,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(Action<DataEvent<CoinExUserTrade>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(Action<DataEvent<CoinExUserTrade>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, CoinExSocketUpdate<CoinExUserTrade>>((receiveTime, originalData, invocations, data) =>
             {
@@ -285,7 +285,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
         }
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(Action<DataEvent<CoinExBalanceUpdate[]>> onMessage, CancellationToken ct = default)
+        public async Task<WebSocketResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(Action<DataEvent<CoinExBalanceUpdate[]>> onMessage, CancellationToken ct = default)
         {
             var internalHandler = new Action<DateTime, string?, int, CoinExSocketUpdate<CoinExBalanceUpdateWrapper>>((receiveTime, originalData, invocations, data) =>
             {

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExSocketClientSpotApi.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExSocketClientSpotApi.cs
@@ -43,8 +43,8 @@ namespace CoinEx.Net.Clients.SpotApiV2
         /// <summary>
         /// Create a new instance of CoinExSocketClient with default options
         /// </summary>
-        internal CoinExSocketClientSpotApi(ILogger logger, CoinExSocketOptions options)
-            : base(logger, CoinExExchange.Metadata.Id, options.Environment.SocketBaseAddress, options, options.SpotOptions)
+        internal CoinExSocketClientSpotApi(ILoggerFactory? loggerFactory, CoinExSocketOptions options)
+            : base(loggerFactory, CoinExExchange.Metadata.Id, options.Environment.SocketBaseAddress, options, options.SpotOptions)
         {
             KeepAliveInterval = TimeSpan.Zero; // Server doesn't correctly respond to ping frames
 

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExSocketClientSpotApiShared.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExSocketClientSpotApiShared.cs
@@ -21,7 +21,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
-        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(CoinExExchange.Metadata, this);
 
         #region Tickers client
         SubscribeTickersOptions ITickersSocketClient.SubscribeAllTickersOptions { get; } = new SubscribeTickersOptions(_exchangeName);
@@ -31,7 +31,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
             if (validationError != null)
                 return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
-            var result = await SubscribeToTickerUpdatesAsync(update => handler(update.ToType<SharedSpotTicker[]>(update.Data.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.OpenPrice == 0 ? null : Math.Round(x.LastPrice / x.OpenPrice * 100 - 100, 2))
+            var result = await SubscribeToTickerUpdatesAsync(update => handler(update.ToType<SharedSpotTicker[]>(update.Data.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.OpenPrice == 0 ? null : Math.Round(x.LastPrice / x.OpenPrice * 100 - 100, 2))
             {
                 QuoteVolume = x.Value
             }).ToArray())), ct).ConfigureAwait(false);
@@ -58,7 +58,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
             {
                 foreach (var ticker in update.Data)
                 {
-                    handler(update.ToType(new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, ticker.Symbol), ticker.Symbol, ticker.LastPrice, ticker.HighPrice, ticker.LowPrice, ticker.Volume, Math.Round(ticker.LastPrice / ticker.OpenPrice * 100 - 100, 2))
+                    handler(update.ToType(new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, ticker.Symbol), ticker.Symbol, ticker.LastPrice, ticker.HighPrice, ticker.LowPrice, ticker.Volume, Math.Round(ticker.LastPrice / ticker.OpenPrice * 100 - 100, 2))
                     {
                         QuoteVolume = ticker.Value
                     }));
@@ -88,7 +88,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 if (update.UpdateType == SocketUpdateType.Snapshot)
                     return;
 
-                handler(update.ToType<SharedTrade[]>(update.Data.Select(x => new SharedTrade(ExchangeSymbolCache.ParseSymbol(_topicId, update.Symbol), update.Symbol!, x.Quantity, x.Price, x.Timestamp)
+                handler(update.ToType<SharedTrade[]>(update.Data.Select(x => new SharedTrade(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, update.Symbol), update.Symbol!, x.Quantity, x.Price, x.Timestamp)
                 {
                     Side = x.Side == OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell
                 }).ToArray()));
@@ -112,7 +112,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
             
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)) : [request.Symbol!.GetSymbol(FormatSymbol)];
-            var result = await SubscribeToBookPriceUpdatesAsync(symbols, update => handler(update.ToType(new SharedBookTicker(ExchangeSymbolCache.ParseSymbol(_topicId, update.Data.Symbol), update.Data.Symbol, update.Data.BestAskPrice, update.Data.BestAskQuantity, update.Data.BestBidPrice, update.Data.BestBidQuantity))), ct).ConfigureAwait(false);
+            var result = await SubscribeToBookPriceUpdatesAsync(symbols, update => handler(update.ToType(new SharedBookTicker(ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, update.Data.Symbol), update.Data.Symbol, update.Data.BestAskPrice, update.Data.BestAskQuantity, update.Data.BestBidPrice, update.Data.BestBidQuantity))), ct).ConfigureAwait(false);
 
             return result;
         }
@@ -163,7 +163,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
             var result = await SubscribeToOrderUpdatesAsync(
                 update => handler(update.ToType<SharedSpotOrder[]>(new[] {
                     new SharedSpotOrder(
-                        ExchangeSymbolCache.ParseSymbol(_topicId, update.Data.Order.Symbol),
+                        ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, update.Data.Order.Symbol),
                         update.Data.Order.Symbol,
                         update.Data.Order.Id.ToString(),
                         update.Data.Order.OrderType == Enums.OrderTypeV2.Limit ? SharedOrderType.Limit : update.Data.Order.OrderType == Enums.OrderTypeV2.Market ? SharedOrderType.Market : SharedOrderType.Other,
@@ -196,7 +196,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
             var result = await SubscribeToUserTradeUpdatesAsync(
                 update => handler(update.ToType<SharedUserTrade[]>(new[] {
                     new SharedUserTrade(
-                        ExchangeSymbolCache.ParseSymbol(_topicId, update.Data.Symbol),
+                        ExchangeSymbolCache.ParseSymbol(_topicId, EnvironmentName, null, update.Data.Symbol),
                         update.Data.Symbol,
                         update.Data.OrderId.ToString(),
                         update.Data.Id.ToString(),

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExSocketClientSpotApiShared.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExSocketClientSpotApiShared.cs
@@ -16,42 +16,42 @@ namespace CoinEx.Net.Clients.SpotApiV2
     internal partial class CoinExSocketClientSpotApi : ICoinExSocketClientSpotApiShared
     {
         private const string _topicId = "CoinExSpot";
-
-        public string Exchange => CoinExExchange.ExchangeName;
-        public TradingMode[] SupportedTradingModes { get; } = new[] { TradingMode.Spot };
+        private const string _exchangeName = "CoinEx";
+        public TradingMode[] SupportedTradingModes => new[] { TradingMode.Spot };
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
 
         #region Tickers client
-        SubscribeTickersOptions ITickersSocketClient.SubscribeAllTickersOptions { get; } = new SubscribeTickersOptions();
-        async Task<ExchangeResult<UpdateSubscription>> ITickersSocketClient.SubscribeToAllTickersUpdatesAsync(SubscribeAllTickersRequest request, Action<DataEvent<SharedSpotTicker[]>> handler, CancellationToken ct)
+        SubscribeTickersOptions ITickersSocketClient.SubscribeAllTickersOptions { get; } = new SubscribeTickersOptions(_exchangeName);
+        async Task<WebSocketResult<UpdateSubscription>> ITickersSocketClient.SubscribeToAllTickersUpdatesAsync(SubscribeAllTickersRequest request, Action<DataEvent<SharedSpotTicker[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ITickersSocketClient)this).SubscribeAllTickersOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeAllTickersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var result = await SubscribeToTickerUpdatesAsync(update => handler(update.ToType<SharedSpotTicker[]>(update.Data.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicId, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.OpenPrice == 0 ? null : Math.Round(x.LastPrice / x.OpenPrice * 100 - 100, 2))
             {
                 QuoteVolume = x.Value
             }).ToArray())), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion
 
         #region Ticker client
-        SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions()
+        SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions(_exchangeName)
         {
             SupportsMultipleSymbols = true,
             MaxSymbolCount = 900
         };
-        async Task<ExchangeResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((ITickerSocketClient)this).SubscribeTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)) : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await SubscribeToTickerUpdatesAsync(symbols, update =>
@@ -65,22 +65,22 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 }
             }, ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Trade client
 
-        EndpointOptions<SubscribeTradeRequest> ITradeSocketClient.SubscribeTradeOptions { get; } = new EndpointOptions<SubscribeTradeRequest>(false)
+        SubscribeTradeOptions ITradeSocketClient.SubscribeTradeOptions { get; } = new SubscribeTradeOptions(_exchangeName, false)
         {
             SupportsMultipleSymbols = true,
             MaxSymbolCount = 900
         };
-        async Task<ExchangeResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ITradeSocketClient)this).SubscribeTradeOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)) : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await SubscribeToTradeUpdatesAsync(symbols, update =>
@@ -94,72 +94,72 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 }).ToArray()));
             }, ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Book Ticker client
 
-        EndpointOptions<SubscribeBookTickerRequest> IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new EndpointOptions<SubscribeBookTickerRequest>(false)
+        SubscribeBookTickerOptions IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new SubscribeBookTickerOptions(_exchangeName, false)
         {
             SupportsMultipleSymbols = true,
             MaxSymbolCount = 900
         };
-        async Task<ExchangeResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((IBookTickerSocketClient)this).SubscribeBookTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeBookTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
             
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)) : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await SubscribeToBookPriceUpdatesAsync(symbols, update => handler(update.ToType(new SharedBookTicker(ExchangeSymbolCache.ParseSymbol(_topicId, update.Data.Symbol), update.Data.Symbol, update.Data.BestAskPrice, update.Data.BestAskQuantity, update.Data.BestBidPrice, update.Data.BestBidQuantity))), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Order Book client
-        SubscribeOrderBookOptions IOrderBookSocketClient.SubscribeOrderBookOptions { get; } = new SubscribeOrderBookOptions(false, new[] { 5, 10, 20, 50 })
+        SubscribeOrderBookOptions IOrderBookSocketClient.SubscribeOrderBookOptions { get; } = new SubscribeOrderBookOptions(_exchangeName, false, new[] { 5, 10, 20, 50 })
         {
             SupportsMultipleSymbols = true,
             MaxSymbolCount = 900
         };
-        async Task<ExchangeResult<UpdateSubscription>> IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(SubscribeOrderBookRequest request, Action<DataEvent<SharedOrderBook>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(SubscribeOrderBookRequest request, Action<DataEvent<SharedOrderBook>> handler, CancellationToken ct)
         {
-            var validationError = ((IOrderBookSocketClient)this).SubscribeOrderBookOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeOrderBookOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)) : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await SubscribeToOrderBookUpdatesAsync(symbols, request.Limit ?? 20, null, true, update => handler(update.ToType(new SharedOrderBook(update.Data.Data.Asks, update.Data.Data.Bids))), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Balance client
-        EndpointOptions<SubscribeBalancesRequest> IBalanceSocketClient.SubscribeBalanceOptions { get; } = new EndpointOptions<SubscribeBalancesRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
+        SubscribeBalanceOptions IBalanceSocketClient.SubscribeBalanceOptions { get; } = new SubscribeBalanceOptions(_exchangeName, false);
+        async Task<WebSocketResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IBalanceSocketClient)this).SubscribeBalanceOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeBalanceOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
             var result = await SubscribeToBalanceUpdatesAsync(
                 update => handler(update.ToType<SharedBalance[]>(update.Data.Select(x => new SharedBalance(x.Asset, x.Available, x.Available + x.Frozen)).ToArray())),
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Spot Order client
 
-        EndpointOptions<SubscribeSpotOrderRequest> ISpotOrderSocketClient.SubscribeSpotOrderOptions { get; } = new EndpointOptions<SubscribeSpotOrderRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> ISpotOrderSocketClient.SubscribeToSpotOrderUpdatesAsync(SubscribeSpotOrderRequest request, Action<DataEvent<SharedSpotOrder[]>> handler, CancellationToken ct)
+        SubscribeSpotOrderOptions ISpotOrderSocketClient.SubscribeSpotOrderOptions { get; } = new SubscribeSpotOrderOptions(_exchangeName, false);
+        async Task<WebSocketResult<UpdateSubscription>> ISpotOrderSocketClient.SubscribeToSpotOrderUpdatesAsync(SubscribeSpotOrderRequest request, Action<DataEvent<SharedSpotOrder[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderSocketClient)this).SubscribeSpotOrderOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
             var result = await SubscribeToOrderUpdatesAsync(
                 update => handler(update.ToType<SharedSpotOrder[]>(new[] {
                     new SharedSpotOrder(
@@ -181,17 +181,17 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 })),
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region User Trade client
-        EndpointOptions<SubscribeUserTradeRequest> IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new EndpointOptions<SubscribeUserTradeRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
+        SubscribeUserTradeOptions IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new SubscribeUserTradeOptions(_exchangeName, false);
+        async Task<WebSocketResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IUserTradeSocketClient)this).SubscribeUserTradeOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeUserTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var result = await SubscribeToUserTradeUpdatesAsync(
                 update => handler(update.ToType<SharedUserTrade[]>(new[] {
@@ -213,7 +213,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
                 } )),
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExSocketClientSpotApiShared.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExSocketClientSpotApiShared.cs
@@ -145,7 +145,12 @@ namespace CoinEx.Net.Clients.SpotApiV2
             if (validationError != null)
                 return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
             var result = await SubscribeToBalanceUpdatesAsync(
-                update => handler(update.ToType<SharedBalance[]>(update.Data.Select(x => new SharedBalance(x.Asset, x.Available, x.Available + x.Frozen)).ToArray())),
+                update => handler(update.ToType<SharedBalance[]>(update.Data.Select(x => 
+                    new SharedBalance(
+                        SupportedTradingModes, 
+                        x.Asset,
+                        x.Available, 
+                        x.Available + x.Frozen)).ToArray())),
                 ct: ct).ConfigureAwait(false);
 
             return result;

--- a/CoinEx.Net/CoinEx.Net.csproj
+++ b/CoinEx.Net/CoinEx.Net.csproj
@@ -55,12 +55,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Crc32.NET" Version="1.2.0" />
+    <PackageReference Include="CryptoExchange.Net" Version="12.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/CoinEx.Net/CoinEx.Net.csproj
+++ b/CoinEx.Net/CoinEx.Net.csproj
@@ -55,10 +55,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Crc32.NET" Version="1.2.0" />
-    <PackageReference Include="CryptoExchange.Net" Version="11.2.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/CoinEx.Net/CoinExExchange.cs
+++ b/CoinEx.Net/CoinExExchange.cs
@@ -28,7 +28,8 @@ namespace CoinEx.Net
                 ["https://viabtc.github.io/coinex_api_en_doc/",
                  "https://docs.coinex.com/api/v2/"],
                 PlatformType.CryptoCurrencyExchange,
-                CentralizationType.Centralized
+                CentralizationType.Centralized,
+                CoinExEnvironment.All
                 );
 
         /// <summary>

--- a/CoinEx.Net/CoinExExchange.cs
+++ b/CoinEx.Net/CoinExExchange.cs
@@ -65,6 +65,12 @@ namespace CoinEx.Net
         public static ExchangeType Type { get; } = ExchangeType.CEX;
 
         internal static JsonSerializerContext _serializerContext = JsonSerializerContextCache.GetOrCreate<CoinExSourceGenerationContext>();
+        internal static ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings
+        {
+            Sort = false,
+            Decimal = DecimalSerialization.String,
+            DateTimes = DateTimeSerialization.MillisecondsString
+        };
 
         /// <summary>
         /// Aliases for CoinEx assets

--- a/CoinEx.Net/CoinExExchange.cs
+++ b/CoinEx.Net/CoinExExchange.cs
@@ -101,7 +101,7 @@ namespace CoinEx.Net
         /// <summary>
         /// Rate limiter configuration for the CoinEx API
         /// </summary>
-        public static CoinExRateLimiters RateLimiter { get; } = new CoinExRateLimiters();
+        public static CoinExRateLimiters RateLimiter { get; set; } = new CoinExRateLimiters();
     }
 
     /// <summary>
@@ -120,13 +120,19 @@ namespace CoinEx.Net
         public event Action<RateLimitUpdateEvent> RateLimitUpdated;
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        internal CoinExRateLimiters()
+        /// <summary>
+        /// ctor
+        /// </summary>
+        public CoinExRateLimiters()
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
             Initialize();
         }
 
-        private void Initialize()
+        /// <summary>
+        /// Initialize the rate limits
+        /// </summary>
+        protected virtual void Initialize()
         {
             var overallGuard = new RateLimitGuard(RateLimitGuard.PerHost, Array.Empty<IGuardFilter>(), 400, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, shared: true);// 400 requests per IP
             CoinExRestPublic = new RateLimitGate("CoinEx Public").AddGuard(overallGuard);

--- a/CoinEx.Net/CoinExUserDataTracker.cs
+++ b/CoinEx.Net/CoinExUserDataTracker.cs
@@ -20,7 +20,6 @@ namespace CoinEx.Net
             SpotUserDataTrackerConfig? config) : base(
                 logger,
                 restClient.SpotApiV2.SharedClient,
-                null,
                 restClient.SpotApiV2.SharedClient,
                 socketClient.SpotApiV2.SharedClient,
                 restClient.SpotApiV2.SharedClient,
@@ -48,7 +47,6 @@ namespace CoinEx.Net
             string? userIdentifier,
             FuturesUserDataTrackerConfig? config) : base(logger,
                 restClient.FuturesApi.SharedClient,
-                null,
                 restClient.FuturesApi.SharedClient,
                 socketClient.FuturesApi.SharedClient,
                 restClient.FuturesApi.SharedClient,

--- a/CoinEx.Net/CoinExV2AuthenticationProvider.cs
+++ b/CoinEx.Net/CoinExV2AuthenticationProvider.cs
@@ -24,7 +24,7 @@ namespace CoinEx.Net
 
         public override void ProcessRequest(RestApiClient apiClient, RestRequestConfiguration request)
         {
-            if (!request.Authenticated)
+            if (!request.RequestDefinition.Authenticated)
                 return;
 
             string parameterString;
@@ -38,12 +38,12 @@ namespace CoinEx.Net
             }
             else
             {
-                parameterString = GetSerializedBody(_serializer, request.BodyParameters ?? new Dictionary<string, object>());
+                parameterString = GetSerializedBody(_serializer, request.BodyParameters ?? new Parameters(CoinExExchange._parameterSerializationSettings));
                 request.SetBodyContent(parameterString);
             }
 
             var timestamp = GetMillisecondTimestamp(apiClient);
-            var signData = request.Method.ToString().ToUpperInvariant() + request.Path + parameterString + timestamp;
+            var signData = request.RequestDefinition.Method.ToString().ToUpperInvariant() + request.RequestDefinition.Path + parameterString + timestamp;
             var sign = SignHMACSHA256(signData, SignOutputType.Hex);
 
             request.Headers ??= new Dictionary<string, string>();

--- a/CoinEx.Net/Converters/CoinExSourceGenerationContext.cs
+++ b/CoinEx.Net/Converters/CoinExSourceGenerationContext.cs
@@ -1,6 +1,7 @@
 using CoinEx.Net.Objects.Internal;
 using CoinEx.Net.Objects.Models.V2;
 using CoinEx.Net.Objects.Sockets.V2;
+using CryptoExchange.Net.Objects;
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
@@ -152,6 +153,8 @@ namespace CoinEx.Net.Converters
     [JsonSerializable(typeof(decimal))]
     [JsonSerializable(typeof(DateTime))]
     [JsonSerializable(typeof(DateTime?))]
+    [JsonSerializable(typeof(Parameters))]
+    [JsonSerializable(typeof(Parameters[]))]
     internal partial class CoinExSourceGenerationContext : JsonSerializerContext
     {
     }

--- a/CoinEx.Net/Interfaces/Clients/FuturesApi/ICoinExRestClientFuturesApiAccount.cs
+++ b/CoinEx.Net/Interfaces/Clients/FuturesApi/ICoinExRestClientFuturesApiAccount.cs
@@ -19,7 +19,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="symbol">["<c>market</c>"] Symbol, for example `ETHUSDT`</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExTradeFee>> GetTradingFeesAsync(string symbol, CancellationToken ct = default);
+        Task<HttpResult<CoinExTradeFee>> GetTradingFeesAsync(string symbol, CancellationToken ct = default);
 
         /// <summary>
         /// Get balances
@@ -27,7 +27,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// </summary>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExFuturesBalance[]>> GetBalancesAsync(CancellationToken ct = default);
+        Task<HttpResult<CoinExFuturesBalance[]>> GetBalancesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Set leverage for a symbol
@@ -38,6 +38,6 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="leverage">["<c>leverage</c>"] Leverage</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExLeverage>> SetLeverageAsync(string symbol, MarginMode mode, int leverage, CancellationToken ct = default);
+        Task<HttpResult<CoinExLeverage>> SetLeverageAsync(string symbol, MarginMode mode, int leverage, CancellationToken ct = default);
     }
 }

--- a/CoinEx.Net/Interfaces/Clients/FuturesApi/ICoinExRestClientFuturesApiExchangeData.cs
+++ b/CoinEx.Net/Interfaces/Clients/FuturesApi/ICoinExRestClientFuturesApiExchangeData.cs
@@ -19,7 +19,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// </summary>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default);
+        Task<HttpResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get list of support symbols
@@ -28,7 +28,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="symbols">["<c>market</c>"] Filter by symbol name; max 10, for example `ETHUSDT`</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExFuturesSymbol[]>> GetSymbolsAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExFuturesSymbol[]>> GetSymbolsAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get symbol tickers
@@ -37,7 +37,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="symbols">["<c>market</c>"] Fitler by symbol names; max 10, for example `ETHUSDT`</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExFuturesTicker[]>> GetTickersAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExFuturesTicker[]>> GetTickersAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get the orderbook for a symbol
@@ -48,7 +48,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="mergeLevel">["<c>interval</c>"] The merge level, 0.00000000001 up to 1000, 0 for no merging</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExOrderBook>> GetOrderBookAsync(string symbol, int limit, string? mergeLevel = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExOrderBook>> GetOrderBookAsync(string symbol, int limit, string? mergeLevel = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get the trade history for a symbol
@@ -59,7 +59,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="lastId">["<c>last_id</c>"] The starting point of the query, 0 means to acquire from the latest record</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExTrade[]>> GetTradeHistoryAsync(string symbol, int? limit = null, long? lastId = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExTrade[]>> GetTradeHistoryAsync(string symbol, int? limit = null, long? lastId = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get klines/candlesticks
@@ -73,7 +73,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="endTime">["<c>end_time</c>"] Filter by end time</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExKline[]>> GetKlinesAsync(string symbol,
+        Task<HttpResult<CoinExKline[]>> GetKlinesAsync(string symbol,
             KlineInterval interval,
             int? limit = null,
             PriceType? priceType = null,
@@ -88,7 +88,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="symbols">["<c>market</c>"] Filter by symbols, for example `ETHUSDT`</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExIndexPrice[]>> GetIndexPricesAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExIndexPrice[]>> GetIndexPricesAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get funding rates
@@ -97,7 +97,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="symbols">["<c>market</c>"] Filter by symbols, for example `ETHUSDT`</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExFundingRate[]>> GetFundingRatesAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExFundingRate[]>> GetFundingRatesAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get historical funding rates
@@ -110,7 +110,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExFundingRateHistory>>> GetFundingRateHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExFundingRateHistory>>> GetFundingRateHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get historical premium index prices
@@ -123,7 +123,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPremiumIndexHistory[]>> GetPremiumIndexPriceHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPremiumIndexHistory[]>> GetPremiumIndexPriceHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get position levels
@@ -132,7 +132,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="symbols">["<c>market</c>"] Filter by symbols; max 10, for example `ETHUSDT`</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPositionLevels[]>> GetPositionLevelsAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPositionLevels[]>> GetPositionLevelsAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get liquidation history
@@ -145,7 +145,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExLiquidation>>> GetLiquidationHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExLiquidation>>> GetLiquidationHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get basis rate history
@@ -156,6 +156,6 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="endTime">["<c>end_time</c>"] Filter by end time</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExBasis[]>> GetBasisHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExBasis[]>> GetBasisHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, CancellationToken ct = default);
     }
 }

--- a/CoinEx.Net/Interfaces/Clients/FuturesApi/ICoinExRestClientFuturesApiTrading.cs
+++ b/CoinEx.Net/Interfaces/Clients/FuturesApi/ICoinExRestClientFuturesApiTrading.cs
@@ -27,7 +27,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="stpMode">["<c>stp_mode</c>"] Self trade prevention mode</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExFuturesOrder>> PlaceOrderAsync(
+        Task<HttpResult<CoinExFuturesOrder>> PlaceOrderAsync(
             string symbol,
             OrderSide side,
             OrderTypeV2 type,
@@ -54,7 +54,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="stpMode">["<c>stp_mode</c>"] Self trade prevention mode</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExStopId>> PlaceStopOrderAsync(
+        Task<HttpResult<CoinExStopId>> PlaceStopOrderAsync(
             string symbol,
             OrderSide side,
             OrderTypeV2 type,
@@ -74,7 +74,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="requests">["<c>orders</c>"] Orders to place</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CallResult<CoinExFuturesOrder>[]>> PlaceMultipleOrdersAsync(
+        Task<HttpResult<CallResult<CoinExFuturesOrder>[]>> PlaceMultipleOrdersAsync(
             IEnumerable<CoinExFuturesPlaceOrderRequest> requests,
             CancellationToken ct = default);
 
@@ -85,7 +85,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="requests">["<c>orders</c>"] Stop orders to place</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CallResult<CoinExStopId>[]>> PlaceMultipleStopOrdersAsync(
+        Task<HttpResult<CallResult<CoinExStopId>[]>> PlaceMultipleStopOrdersAsync(
             IEnumerable<CoinExFuturesPlaceStopOrderRequest> requests,
             CancellationToken ct = default);
 
@@ -97,7 +97,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="orderId">["<c>order_id</c>"] Order id</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExFuturesOrder>> GetOrderAsync(string symbol, long orderId, CancellationToken ct = default);
+        Task<HttpResult<CoinExFuturesOrder>> GetOrderAsync(string symbol, long orderId, CancellationToken ct = default);
 
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExFuturesOrder>>> GetOpenOrdersAsync(string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExFuturesOrder>>> GetOpenOrdersAsync(string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get a list of closed orders. Note that orders canceled without having any trades will not be returned
@@ -124,7 +124,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExFuturesOrder>>> GetClosedOrdersAsync(string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExFuturesOrder>>> GetClosedOrdersAsync(string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get a list of open stop orders
@@ -137,7 +137,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExStopOrder>>> GetOpenStopOrdersAsync(string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExStopOrder>>> GetOpenStopOrdersAsync(string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get a list of closed stop orders. Note that orders canceled without having any trades will not be returned
@@ -149,7 +149,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExStopOrder>>> GetClosedStopOrdersAsync(string? symbol = null, OrderSide? side = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExStopOrder>>> GetClosedStopOrdersAsync(string? symbol = null, OrderSide? side = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Edit an active order
@@ -161,7 +161,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="price">["<c>price</c>"] New price</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExFuturesOrder>> EditOrderAsync(
+        Task<HttpResult<CoinExFuturesOrder>> EditOrderAsync(
             string symbol,
             long orderId,
             decimal quantity,
@@ -179,7 +179,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="triggerPrice">["<c>trigger_price</c>"] New trigger price</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExStopId>> EditStopOrderAsync(
+        Task<HttpResult<CoinExStopId>> EditStopOrderAsync(
             string symbol,
             long stopOrderId,
             decimal quantity,
@@ -195,7 +195,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="side">["<c>side</c>"] Only cancel a specific order side</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult> CancelAllOrdersAsync(string symbol, OrderSide? side = null, CancellationToken ct = default);
+        Task<HttpResult> CancelAllOrdersAsync(string symbol, OrderSide? side = null, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel an active order
@@ -205,7 +205,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="orderId">["<c>order_id</c>"] Id of order to cancel</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExFuturesOrder>> CancelOrderAsync(string symbol, long orderId, CancellationToken ct = default);
+        Task<HttpResult<CoinExFuturesOrder>> CancelOrderAsync(string symbol, long orderId, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel an active stop order
@@ -215,7 +215,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="stopOrderId">["<c>stop_id</c>"] Id of stop order to cancel</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExStopOrder>> CancelStopOrderAsync(string symbol, long stopOrderId, CancellationToken ct = default);
+        Task<HttpResult<CoinExStopOrder>> CancelStopOrderAsync(string symbol, long stopOrderId, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel an active order by its client order id
@@ -225,7 +225,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="clientOrderId">["<c>client_id</c>"] Client order id of order to cancel</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExBatchResult<CoinExFuturesOrder>[]>> CancelOrderByClientOrderIdAsync(string symbol, string clientOrderId, CancellationToken ct = default);
+        Task<HttpResult<CoinExBatchResult<CoinExFuturesOrder>[]>> CancelOrderByClientOrderIdAsync(string symbol, string clientOrderId, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel an active stop order by its client order id
@@ -235,7 +235,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="clientStopOrderId">["<c>client_id</c>"] Client order id of stop order to cancel</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExBatchResult<CoinExStopOrder>[]>> CancelStopOrderByClientOrderIdAsync(string symbol, string clientStopOrderId, CancellationToken ct = default);
+        Task<HttpResult<CoinExBatchResult<CoinExStopOrder>[]>> CancelStopOrderByClientOrderIdAsync(string symbol, string clientStopOrderId, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel multiple orders
@@ -245,7 +245,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="orderIds">["<c>order_ids</c>"] Ids of orders to cancel</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExBatchResult<CoinExFuturesOrder>[]>> CancelOrdersAsync(string symbol, IEnumerable<long> orderIds, CancellationToken ct = default);
+        Task<HttpResult<CoinExBatchResult<CoinExFuturesOrder>[]>> CancelOrdersAsync(string symbol, IEnumerable<long> orderIds, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel multiple stop orders
@@ -255,7 +255,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="orderIds">["<c>stop_ids</c>"] Ids of stop orders to cancel</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExBatchResult<CoinExStopOrder>[]>> CancelStopOrdersAsync(string symbol, IEnumerable<long> orderIds, CancellationToken ct = default);
+        Task<HttpResult<CoinExBatchResult<CoinExStopOrder>[]>> CancelStopOrdersAsync(string symbol, IEnumerable<long> orderIds, CancellationToken ct = default);
 
         /// <summary>
         /// Get trade list
@@ -269,7 +269,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExUserTrade>>> GetUserTradesAsync(string symbol, OrderSide? side = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExUserTrade>>> GetUserTradesAsync(string symbol, OrderSide? side = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get trades for a specific order
@@ -281,7 +281,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExUserTrade>>> GetOrderTradesAsync(string symbol, long orderId, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExUserTrade>>> GetOrderTradesAsync(string symbol, long orderId, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get user positions
@@ -292,7 +292,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExPosition>>> GetPositionsAsync(string? symbol = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExPosition>>> GetPositionsAsync(string? symbol = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get position history
@@ -305,7 +305,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExPosition>>> GetPositionHistoryAsync(string? symbol = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExPosition>>> GetPositionHistoryAsync(string? symbol = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// (partially) Close an open position
@@ -319,7 +319,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="hidden">["<c>is_hide</c>"] Is hidden</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExFuturesOrder>> ClosePositionAsync(string symbol, OrderTypeV2 orderType, decimal? price = null, decimal? quantity = null, string? clientOrderId = null, bool? hidden = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExFuturesOrder>> ClosePositionAsync(string symbol, OrderTypeV2 orderType, decimal? price = null, decimal? quantity = null, string? clientOrderId = null, bool? hidden = null, CancellationToken ct = default);
 
         /// <summary>
         /// Adjust the margin for a position. Positive quantity for increasing, negative quantity for decreasing
@@ -329,7 +329,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="quantity">["<c>amount</c>"] Quantity to increase (positive number) or decrease (negative number)</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPosition>> AdjustPositionMarginAsync(string symbol, decimal quantity, CancellationToken ct = default);
+        Task<HttpResult<CoinExPosition>> AdjustPositionMarginAsync(string symbol, decimal quantity, CancellationToken ct = default);
 
         /// <summary>
         /// Set stop loss for a position
@@ -341,7 +341,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="stopLossQuantity">["<c>stop_loss_amount</c>"] Stop loss quantity, null for full position</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPosition>> SetStopLossAsync(string symbol, PriceType stopLossType, decimal stopLossPrice, decimal? stopLossQuantity = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPosition>> SetStopLossAsync(string symbol, PriceType stopLossType, decimal stopLossPrice, decimal? stopLossQuantity = null, CancellationToken ct = default);
 
         /// <summary>
         /// Edit stop loss order
@@ -353,7 +353,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="stopLossPrice">["<c>stop_loss_price</c>"] Stop loss price</param>
         /// <param name="stopLossQuantity">["<c>stop_loss_amount</c>"] Stop loss quantity</param>
         /// <param name="ct">Cancelation Token</param>
-        Task<WebCallResult<CoinExPosition>> EditStopLossAsync(string symbol, long stopLossOrderId, PriceType? stopLossType = null, decimal? stopLossPrice = null, decimal? stopLossQuantity = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPosition>> EditStopLossAsync(string symbol, long stopLossOrderId, PriceType? stopLossType = null, decimal? stopLossPrice = null, decimal? stopLossQuantity = null, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel an active position stop loss
@@ -362,7 +362,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="symbol">["<c>market</c>"] Symbol, for example `ETHUSDT`</param>
         /// <param name="stopLossOrderId">["<c>stop_loss_id</c>"] Stop loss order id. If not not provided all stop losses are canceled</param>
         /// <param name="ct">Cancelation Token</param>
-        Task<WebCallResult<CoinExPosition>> CancelStopLossAsync(string symbol, long? stopLossOrderId = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPosition>> CancelStopLossAsync(string symbol, long? stopLossOrderId = null, CancellationToken ct = default);
 
         /// <summary>
         /// Set take profit for a position
@@ -373,7 +373,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="takeProfitPrice">["<c>take_profit_price</c>"] Take profit price</param>
         /// <param name="takeProfitQuantity">["<c>take_profit_amount</c>"] Take profit quantity, null for full position</param>
         /// <param name="ct">Cancelation Token</param>
-        Task<WebCallResult<CoinExPosition>> SetTakeProfitAsync(string symbol, PriceType takeProfitType, decimal takeProfitPrice, decimal? takeProfitQuantity = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPosition>> SetTakeProfitAsync(string symbol, PriceType takeProfitType, decimal takeProfitPrice, decimal? takeProfitQuantity = null, CancellationToken ct = default);
 
         /// <summary>
         /// Edit take profit order
@@ -385,7 +385,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="takeProfitPrice">["<c>take_profit_price</c>"] Take profit price</param>
         /// <param name="takeProfitQuantity">["<c>take_profit_amount</c>"] Take profit quantity</param>
         /// <param name="ct">Cancelation Token</param>
-        Task<WebCallResult<CoinExPosition>> EditTakeProfitAsync(string symbol, long takeProfitOrderId, PriceType? takeProfitType = null, decimal? takeProfitPrice = null, decimal? takeProfitQuantity = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPosition>> EditTakeProfitAsync(string symbol, long takeProfitOrderId, PriceType? takeProfitType = null, decimal? takeProfitPrice = null, decimal? takeProfitQuantity = null, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel an active position take profit
@@ -394,7 +394,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="symbol">["<c>market</c>"] Symbol, for example `ETHUSDT`</param>
         /// <param name="takeProfitOrderId">["<c>take_profit_id</c>"] Take profit order id. If not not provided all take profits are canceled</param>
         /// <param name="ct">Cancelation Token</param>
-        Task<WebCallResult<CoinExPosition>> CancelTakeProfitAsync(string symbol, long? takeProfitOrderId = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPosition>> CancelTakeProfitAsync(string symbol, long? takeProfitOrderId = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get margin adjustment history
@@ -408,7 +408,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExPositionMargin>>> GetMarginHistoryAsync(string symbol, long positionId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExPositionMargin>>> GetMarginHistoryAsync(string symbol, long positionId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get funding rate history
@@ -422,7 +422,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExPositionFundingRate>>> GetFundingRateHistoryAsync(string symbol, long positionId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExPositionFundingRate>>> GetFundingRateHistoryAsync(string symbol, long positionId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get auto deleveraging history
@@ -436,7 +436,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExPositionAdl>>> GetAutoDeleverageHistoryAsync(string symbol, long positionId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExPositionAdl>>> GetAutoDeleverageHistoryAsync(string symbol, long positionId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get position settlement history
@@ -450,6 +450,6 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExPositionSettlement>>> GetAutoSettlementHistoryAsync(string symbol, long positionId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExPositionSettlement>>> GetAutoSettlementHistoryAsync(string symbol, long positionId, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
     }
 }

--- a/CoinEx.Net/Interfaces/Clients/FuturesApi/ICoinExSocketClientFuturesApi.cs
+++ b/CoinEx.Net/Interfaces/Clients/FuturesApi/ICoinExSocketClientFuturesApi.cs
@@ -29,7 +29,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExFuturesTickerUpdate[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExFuturesTickerUpdate[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to symbol ticker updates for all symbols. Note that only one ticker subscription can be active at the same time; new ticker subscription will override the old subscriptions.
@@ -38,7 +38,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(Action<DataEvent<CoinExFuturesTickerUpdate[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(Action<DataEvent<CoinExFuturesTickerUpdate[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to order book updates
@@ -51,7 +51,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int depth, string? mergeLevel, bool fullBookUpdates, Action<DataEvent<Objects.Models.V2.CoinExOrderBook>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int depth, string? mergeLevel, bool fullBookUpdates, Action<DataEvent<Objects.Models.V2.CoinExOrderBook>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to order book updates
@@ -64,7 +64,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, int depth, string? mergeLevel, bool fullBookUpdates, Action<DataEvent<Objects.Models.V2.CoinExOrderBook>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, int depth, string? mergeLevel, bool fullBookUpdates, Action<DataEvent<Objects.Models.V2.CoinExOrderBook>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to live trade updates
@@ -74,7 +74,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to live trade updates
@@ -84,7 +84,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to live trade updates
@@ -93,7 +93,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to index price updates
@@ -103,7 +103,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToIndexPriceUpdatesAsync(string symbol, Action<DataEvent<CoinExIndexPriceUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToIndexPriceUpdatesAsync(string symbol, Action<DataEvent<CoinExIndexPriceUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to index price updates
@@ -113,7 +113,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToIndexPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExIndexPriceUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToIndexPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExIndexPriceUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to book price updates
@@ -123,7 +123,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(string symbol, Action<DataEvent<CoinExBookPriceUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(string symbol, Action<DataEvent<CoinExBookPriceUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to book price updates
@@ -133,7 +133,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExBookPriceUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExBookPriceUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to premium index price updates
@@ -143,7 +143,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToPremiumIndexUpdatesAsync(string symbol, Action<DataEvent<CoinExPremiumUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToPremiumIndexUpdatesAsync(string symbol, Action<DataEvent<CoinExPremiumUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to premium index price updates
@@ -153,7 +153,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToPremiumIndexUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExPremiumUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToPremiumIndexUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExPremiumUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user order updates
@@ -162,7 +162,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(Action<DataEvent<CoinExFuturesOrderUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(Action<DataEvent<CoinExFuturesOrderUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user stop order updates
@@ -171,7 +171,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToStopOrderUpdatesAsync(Action<DataEvent<CoinExStopOrderUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToStopOrderUpdatesAsync(Action<DataEvent<CoinExStopOrderUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user trade updates
@@ -180,7 +180,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(Action<DataEvent<CoinExUserTrade>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(Action<DataEvent<CoinExUserTrade>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user balance updates
@@ -189,7 +189,7 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(Action<DataEvent<CoinExFuturesBalance[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(Action<DataEvent<CoinExFuturesBalance[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user position updates
@@ -198,6 +198,6 @@ namespace CoinEx.Net.Interfaces.Clients.FuturesApi
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(Action<DataEvent<CoinExPositionUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(Action<DataEvent<CoinExPositionUpdate>> onMessage, CancellationToken ct = default);
     }
 }

--- a/CoinEx.Net/Interfaces/Clients/ICoinExUserClientProvider.cs
+++ b/CoinEx.Net/Interfaces/Clients/ICoinExUserClientProvider.cs
@@ -22,6 +22,11 @@ namespace CoinEx.Net.Interfaces.Clients
         public void ClearUserClients(string userIdentifier);
 
         /// <summary>
+        /// Clear all client from the cache
+        /// </summary>
+        void Clear();
+
+        /// <summary>
         /// Get the Rest client for a specific user. In case the client does not exist yet it will be created and the <paramref name="credentials"/> should be provided, unless <see cref="InitializeUserClient" /> has been called prior for this user.
         /// </summary>
         /// <param name="userIdentifier">The identifier for user</param>

--- a/CoinEx.Net/Interfaces/Clients/SpotApiV2/ICoinExRestClientSpotApiAccount.cs
+++ b/CoinEx.Net/Interfaces/Clients/SpotApiV2/ICoinExRestClientSpotApiAccount.cs
@@ -26,7 +26,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="accountType">["<c>market_type</c>"] Account type</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExTradeFee>> GetTradingFeesAsync(string symbol, AccountType accountType, CancellationToken ct = default);
+        Task<HttpResult<CoinExTradeFee>> GetTradingFeesAsync(string symbol, AccountType accountType, CancellationToken ct = default);
 
         /// <summary>
         /// Update account settings
@@ -40,7 +40,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="cetDiscountEnabled">["<c>cet_discount_enabled</c>"] Global switch for CET Deduction</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult> SetAccountConfigAsync(bool cetDiscountEnabled, CancellationToken ct = default);
+        Task<HttpResult> SetAccountConfigAsync(bool cetDiscountEnabled, CancellationToken ct = default);
 
         /// <summary>
         /// Get balances
@@ -53,7 +53,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// </summary>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExBalance[]>> GetBalancesAsync(CancellationToken ct = default);
+        Task<HttpResult<CoinExBalance[]>> GetBalancesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get margin balances
@@ -66,7 +66,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// </summary>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExMarginBalance[]>> GetMarginBalancesAsync(CancellationToken ct = default);
+        Task<HttpResult<CoinExMarginBalance[]>> GetMarginBalancesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get balances in the financial account
@@ -79,7 +79,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// </summary>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExBalance[]>> GetFinancialBalancesAsync(CancellationToken ct = default);
+        Task<HttpResult<CoinExBalance[]>> GetFinancialBalancesAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get credit account info
@@ -92,7 +92,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// </summary>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExCreditBalance>> GetCreditAccountAsync(CancellationToken ct = default);
+        Task<HttpResult<CoinExCreditBalance>> GetCreditAccountAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get automated market maker account liquidity
@@ -105,7 +105,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// </summary>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExAmmBalance[]>> GetAutoMarketMakerAccountLiquidityAsync(CancellationToken ct = default);
+        Task<HttpResult<CoinExAmmBalance[]>> GetAutoMarketMakerAccountLiquidityAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Apply for margin borrowing
@@ -122,7 +122,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="autoRenew">["<c>is_auto_renew</c>"] Whether to renew automatically. Automatic renewal means that after the loan expires, the system will renew the loan based on the latest borrowing interest rate and cycle.</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExBorrow>> MarginBorrowAsync(string symbol, string asset, decimal quantity, bool autoRenew, CancellationToken ct = default);
+        Task<HttpResult<CoinExBorrow>> MarginBorrowAsync(string symbol, string asset, decimal quantity, bool autoRenew, CancellationToken ct = default);
 
         /// <summary>
         /// Repay a margin loan
@@ -139,7 +139,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="borrowId">["<c>borrow_id</c>"] Loan record ID</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult> MarginRepayAsync(string symbol, string asset, decimal quantity, long? borrowId = null, CancellationToken ct = default);
+        Task<HttpResult> MarginRepayAsync(string symbol, string asset, decimal quantity, long? borrowId = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get borrow history
@@ -156,7 +156,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExBorrow>>> GetBorrowHistoryAsync(string? symbol = null, BorrowStatus? status = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExBorrow>>> GetBorrowHistoryAsync(string? symbol = null, BorrowStatus? status = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get borrow limits
@@ -171,7 +171,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="asset">["<c>ccy</c>"] Asset</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExBorrowLimit>> GetBorrowLimitAsync(string symbol, string asset, CancellationToken ct = default);
+        Task<HttpResult<CoinExBorrowLimit>> GetBorrowLimitAsync(string symbol, string asset, CancellationToken ct = default);
 
         /// <summary>
         /// Get the deposit address for an asset
@@ -186,7 +186,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="network">["<c>chain</c>"] Network</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExDepositAddress>> GetDepositAddressAsync(string asset, string network, CancellationToken ct = default);
+        Task<HttpResult<CoinExDepositAddress>> GetDepositAddressAsync(string asset, string network, CancellationToken ct = default);
 
         /// <summary>
         /// Renew deposit address
@@ -201,7 +201,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="network">["<c>chain</c>"] Network</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExDepositAddress>> RenewDepositAddressAsync(string asset, string network, CancellationToken ct = default);
+        Task<HttpResult<CoinExDepositAddress>> RenewDepositAddressAsync(string asset, string network, CancellationToken ct = default);
 
         /// <summary>
         /// Get deposit history
@@ -219,7 +219,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExDeposit>>> GetDepositHistoryAsync(string? asset = null, string? transactionId = null, DepositStatus? status = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExDeposit>>> GetDepositHistoryAsync(string? asset = null, string? transactionId = null, DepositStatus? status = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Withdraw funds to an external address or another CoinEx user
@@ -240,7 +240,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="extraParameters">["<c>extra</c>"] If it is a withdrawal from the KDA chain, you need to append the chain_id field to the extra field</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExWithdrawal>> WithdrawAsync(string asset, decimal quantity, string toAddress, MovementMethod? method = null, string? network = null, string? remark = null, string? memo = null, Dictionary<string, object>? extraParameters = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExWithdrawal>> WithdrawAsync(string asset, decimal quantity, string toAddress, MovementMethod? method = null, string? network = null, string? remark = null, string? memo = null, Dictionary<string, object>? extraParameters = null, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel a pending withdrawal
@@ -254,7 +254,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="withdrawalId">["<c>withdraw_id</c>"] The withdrawal id</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult> CancelWithdrawalAsync(long withdrawalId, CancellationToken ct = default);
+        Task<HttpResult> CancelWithdrawalAsync(long withdrawalId, CancellationToken ct = default);
 
         /// <summary>
         /// Get withdrawal history
@@ -272,7 +272,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExWithdrawal>>> GetWithdrawalHistoryAsync(string? asset = null, long? withdrawId = null, WithdrawStatusV2? status = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExWithdrawal>>> GetWithdrawalHistoryAsync(string? asset = null, long? withdrawId = null, WithdrawStatusV2? status = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get withdraw and deposit information for an asset
@@ -286,7 +286,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="asset">["<c>ccy</c>"] The asset, for example `ETH`</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExDepositWithdrawalConfig>> GetDepositWithdrawalConfigAsync(string asset, CancellationToken ct = default);
+        Task<HttpResult<CoinExDepositWithdrawalConfig>> GetDepositWithdrawalConfigAsync(string asset, CancellationToken ct = default);
 
         /// <summary>
         /// Get withdraw and deposit information for all assets
@@ -299,7 +299,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// </summary>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExDepositWithdrawalConfig[]>> GetAllDepositWithdrawalConfigsAsync(CancellationToken ct = default);
+        Task<HttpResult<CoinExDepositWithdrawalConfig[]>> GetAllDepositWithdrawalConfigsAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Transfer between accounts
@@ -317,7 +317,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="marginSymbol">["<c>market</c>"] Margin symbol, only needed when from or to account type is Margin</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult> TransferAsync(string asset, AccountType fromAccount, AccountType toAccount, decimal quantity, string? marginSymbol = null, CancellationToken ct = default);
+        Task<HttpResult> TransferAsync(string asset, AccountType fromAccount, AccountType toAccount, decimal quantity, string? marginSymbol = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get transfer history
@@ -337,7 +337,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExTransfer>>> GetTransfersAsync(string asset, AccountType transferType, TransferStatus? status = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExTransfer>>> GetTransfersAsync(string asset, AccountType transferType, TransferStatus? status = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Add AAM liquidity
@@ -353,7 +353,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="quoteAssetQuantity">["<c>quote_ccy_amount</c>"] Quote asset quantity to add</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExAamLiquidity>> AddAutoMarketMakerLiquidityAsync(string symbol, decimal baseAssetQuantity, decimal quoteAssetQuantity, CancellationToken ct = default);
+        Task<HttpResult<CoinExAamLiquidity>> AddAutoMarketMakerLiquidityAsync(string symbol, decimal baseAssetQuantity, decimal quoteAssetQuantity, CancellationToken ct = default);
 
         /// <summary>
         /// Remove AAM liquidity. Currently only support withdrawing all liquidity
@@ -367,7 +367,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="symbol">["<c>market</c>"] Symbol, for example `ETHUSDT`</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExAamLiquidity>> RemoveAutoMarketMakerLiquidityAsync(string symbol, CancellationToken ct = default);
+        Task<HttpResult<CoinExAamLiquidity>> RemoveAutoMarketMakerLiquidityAsync(string symbol, CancellationToken ct = default);
 
         /// <summary>
         /// Get account transaction history
@@ -386,6 +386,6 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExTransaction>>> GetTransactionHistoryAsync(TransactionType transactionType, string? asset = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExTransaction>>> GetTransactionHistoryAsync(TransactionType transactionType, string? asset = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
     }
 }

--- a/CoinEx.Net/Interfaces/Clients/SpotApiV2/ICoinExRestClientSpotApiExchangeData.cs
+++ b/CoinEx.Net/Interfaces/Clients/SpotApiV2/ICoinExRestClientSpotApiExchangeData.cs
@@ -24,7 +24,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// </summary>
         /// <param name="ct">Cancelation token</param>
         /// <returns></returns>
-        Task<WebCallResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default);
+        Task<HttpResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default);
 
         // Doesn't seem to exist on the url specified in the docs
         ///// <summary>
@@ -33,7 +33,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         ///// <para><a href="https://docs.coinex.com/api/v2/common/http/maintain" /></para>
         ///// <param name="ct">Cancelation token</param>
         ///// <returns></returns>
-        //Task<WebCallResult<CoinExMaintenance[]>> GetMaintenanceInfoAsync(CancellationToken ct = default);
+        //Task<HttpResult<CoinExMaintenance[]>> GetMaintenanceInfoAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get symbol information
@@ -46,7 +46,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// </summary>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExSymbol[]>> GetSymbolsAsync(CancellationToken ct = default);
+        Task<HttpResult<CoinExSymbol[]>> GetSymbolsAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get asset information
@@ -59,7 +59,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// </summary>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExAsset[]>> GetAssetsAsync(CancellationToken ct = default);
+        Task<HttpResult<CoinExAsset[]>> GetAssetsAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Get symbol tickers
@@ -73,7 +73,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="symbols">["<c>market</c>"] Fitler by symbol names, for example `ETHUSDT`</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExTicker[]>> GetTickersAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExTicker[]>> GetTickersAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get the orderbook for a symbol
@@ -89,7 +89,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="mergeLevel">["<c>interval</c>"] The merge level, 0.00000000001 up to 1000, 0 for no merging</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExOrderBook>> GetOrderBookAsync(string symbol, int limit, string? mergeLevel = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExOrderBook>> GetOrderBookAsync(string symbol, int limit, string? mergeLevel = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get the trade history for a symbol
@@ -105,7 +105,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="lastId">["<c>last_id</c>"] The starting point of the query, 0 means to acquire from the latest record</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExTrade[]>> GetTradeHistoryAsync(string symbol, int? limit = null, long? lastId = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExTrade[]>> GetTradeHistoryAsync(string symbol, int? limit = null, long? lastId = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get klines/candlesticks
@@ -124,7 +124,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="endTime">["<c>end_time</c>"] Filter by end time</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExKline[]>> GetKlinesAsync(
+        Task<HttpResult<CoinExKline[]>> GetKlinesAsync(
             string symbol,
             KlineInterval interval,
             int? limit = null,
@@ -145,6 +145,6 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="symbols">["<c>market</c>"] Filter by symbols, for example `ETHUSDT`</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExIndexPrice[]>> GetIndexPricesAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExIndexPrice[]>> GetIndexPricesAsync(IEnumerable<string>? symbols = null, CancellationToken ct = default);
     }
 }

--- a/CoinEx.Net/Interfaces/Clients/SpotApiV2/ICoinExRestClientSpotApiTrading.cs
+++ b/CoinEx.Net/Interfaces/Clients/SpotApiV2/ICoinExRestClientSpotApiTrading.cs
@@ -34,7 +34,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="stpMode">["<c>stp_mode</c>"] Self trade prevention mode</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExOrder>> PlaceOrderAsync(
+        Task<HttpResult<CoinExOrder>> PlaceOrderAsync(
             string symbol,
             AccountType accountType,
             OrderSide side,
@@ -69,7 +69,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="stpMode">["<c>stp_mode</c>"] Self trade prevention mode</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExStopId>> PlaceStopOrderAsync(
+        Task<HttpResult<CoinExStopId>> PlaceStopOrderAsync(
             string symbol,
             AccountType accountType,
             OrderSide side,
@@ -95,7 +95,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="requests">["<c>orders</c>"] The orders to place</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CallResult<CoinExBatchOrderResult>[]>> PlaceMultipleOrdersAsync(
+        Task<HttpResult<CallResult<CoinExBatchOrderResult>[]>> PlaceMultipleOrdersAsync(
             IEnumerable<CoinExPlaceOrderRequest> requests,
             CancellationToken ct = default);
 
@@ -111,7 +111,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="requests">["<c>orders</c>"] The stop orders to place</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CallResult<CoinExStopId>[]>> PlaceMultipleStopOrdersAsync(
+        Task<HttpResult<CallResult<CoinExStopId>[]>> PlaceMultipleStopOrdersAsync(
            IEnumerable<CoinExPlaceStopOrderRequest> requests,
            CancellationToken ct = default);
 
@@ -128,7 +128,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="orderId">["<c>order_id</c>"] Order id</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExOrder>> GetOrderAsync(string symbol, long orderId, CancellationToken ct = default);
+        Task<HttpResult<CoinExOrder>> GetOrderAsync(string symbol, long orderId, CancellationToken ct = default);
 
         /// <summary>
         /// Get a list of open orders
@@ -147,7 +147,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExOrder>>> GetOpenOrdersAsync(AccountType accountType, string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExOrder>>> GetOpenOrdersAsync(AccountType accountType, string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get a list of closed orders. Note that orders canceled without having any trades will not be returned
@@ -166,7 +166,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExOrder>>> GetClosedOrdersAsync(AccountType accountType, string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExOrder>>> GetClosedOrdersAsync(AccountType accountType, string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get a list of open stop orders
@@ -185,7 +185,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExStopOrder>>> GetOpenStopOrdersAsync(AccountType accountType, string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExStopOrder>>> GetOpenStopOrdersAsync(AccountType accountType, string? symbol = null, OrderSide? side = null, string? clientOrderId = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get a list of closed stop orders. Note that orders canceled without having any trades will not be returned
@@ -203,7 +203,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExStopOrder>>> GetClosedStopOrdersAsync(AccountType accountType, string? symbol = null, OrderSide? side = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExStopOrder>>> GetClosedStopOrdersAsync(AccountType accountType, string? symbol = null, OrderSide? side = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Edit an active order
@@ -221,7 +221,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="price">["<c>price</c>"] New price</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExOrder>> EditOrderAsync(
+        Task<HttpResult<CoinExOrder>> EditOrderAsync(
             string symbol,
             AccountType accountType,
             long orderId,
@@ -246,7 +246,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="triggerPrice">["<c>trigger_price</c>"] New trigger price</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExStopId>> EditStopOrderAsync(
+        Task<HttpResult<CoinExStopId>> EditStopOrderAsync(
             string symbol,
             AccountType accountType,
             long stopOrderId,
@@ -269,7 +269,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="side">["<c>side</c>"] Only cancel a specific order side</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult> CancelAllOrdersAsync(string symbol, AccountType accountType, OrderSide? side = null, CancellationToken ct = default);
+        Task<HttpResult> CancelAllOrdersAsync(string symbol, AccountType accountType, OrderSide? side = null, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel an active order
@@ -285,7 +285,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="orderId">["<c>order_id</c>"] Id of order to cancel</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExOrder>> CancelOrderAsync(string symbol, AccountType accountType, long orderId, CancellationToken ct = default);
+        Task<HttpResult<CoinExOrder>> CancelOrderAsync(string symbol, AccountType accountType, long orderId, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel multiple orders
@@ -300,7 +300,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="orderIds">["<c>order_ids</c>"] Ids of orders to cancel</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExBatchResult<CoinExOrder>[]>> CancelOrdersAsync(string symbol, IEnumerable<long> orderIds, CancellationToken ct = default);
+        Task<HttpResult<CoinExBatchResult<CoinExOrder>[]>> CancelOrdersAsync(string symbol, IEnumerable<long> orderIds, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel an active stop order
@@ -316,7 +316,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="stopOrderId">["<c>stop_id</c>"] Id of stop order to cancel</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExStopOrder>> CancelStopOrderAsync(string symbol, AccountType accountType, long stopOrderId, CancellationToken ct = default);
+        Task<HttpResult<CoinExStopOrder>> CancelStopOrderAsync(string symbol, AccountType accountType, long stopOrderId, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel an active order by its client order id
@@ -332,7 +332,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="clientOrderId">["<c>client_id</c>"] Client order id of order to cancel</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExOrder[]>> CancelOrdersByClientOrderIdAsync(string symbol, AccountType accountType, string clientOrderId, CancellationToken ct = default);
+        Task<HttpResult<CoinExOrder[]>> CancelOrdersByClientOrderIdAsync(string symbol, AccountType accountType, string clientOrderId, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel an active stop order by its client order id
@@ -348,7 +348,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="clientStopOrderId">["<c>client_id</c>"] Client order id of stop order to cancel</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExStopOrder[]>> CancelStopOrdersByClientOrderIdAsync(string symbol, AccountType accountType, string clientStopOrderId, CancellationToken ct = default);
+        Task<HttpResult<CoinExStopOrder[]>> CancelStopOrdersByClientOrderIdAsync(string symbol, AccountType accountType, string clientStopOrderId, CancellationToken ct = default);
 
         /// <summary>
         /// Cancel multiple stop orders
@@ -363,7 +363,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="orderIds">["<c>stop_ids</c>"] Stop order ids to cancel</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExBatchResult<CoinExStopOrder>[]>> CancelStopOrdersAsync(string symbol, IEnumerable<long> orderIds, CancellationToken ct = default);
+        Task<HttpResult<CoinExBatchResult<CoinExStopOrder>[]>> CancelStopOrdersAsync(string symbol, IEnumerable<long> orderIds, CancellationToken ct = default);
 
         /// <summary>
         /// Get trade list
@@ -383,7 +383,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExUserTrade>>> GetUserTradesAsync(string symbol, AccountType accountType, OrderSide? side = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExUserTrade>>> GetUserTradesAsync(string symbol, AccountType accountType, OrderSide? side = null, DateTime? startTime = null, DateTime? endTime = null, int? page = null, int? pageSize = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get trades for a specific order
@@ -401,6 +401,6 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="pageSize">["<c>limit</c>"] Page size</param>
         /// <param name="ct">Cancelation Token</param>
         /// <returns></returns>
-        Task<WebCallResult<CoinExPaginated<CoinExUserTrade>>> GetOrderTradesAsync(string symbol, AccountType accountType, long orderId, int? page = null, int? pageSize = null, CancellationToken ct = default);
+        Task<HttpResult<CoinExPaginated<CoinExUserTrade>>> GetOrderTradesAsync(string symbol, AccountType accountType, long orderId, int? page = null, int? pageSize = null, CancellationToken ct = default);
     }
 }

--- a/CoinEx.Net/Interfaces/Clients/SpotApiV2/ICoinExSocketClientSpotApi.cs
+++ b/CoinEx.Net/Interfaces/Clients/SpotApiV2/ICoinExSocketClientSpotApi.cs
@@ -27,7 +27,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToSystemNoticeUpdatesAsync(Action<DataEvent<CoinExMaintenance[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToSystemNoticeUpdatesAsync(Action<DataEvent<CoinExMaintenance[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to symbol ticker updates for the specified symbols. Note that only one ticker subscription can be active at the same time; new ticker subscription will override the old subscriptions.
@@ -42,7 +42,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExTicker[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExTicker[]>> onMessage, CancellationToken ct = default);
         
         /// <summary>
         /// Subscribe to symbol ticker updates for all symbols. Note that only one ticker subscription can be active at the same time; new ticker subscription will override the old subscriptions.
@@ -56,7 +56,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(Action<DataEvent<CoinExTicker[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(Action<DataEvent<CoinExTicker[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to order book updates
@@ -74,7 +74,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int depth, string? mergeLevel, bool fullBookUpdates, Action<DataEvent<Objects.Models.V2.CoinExOrderBook>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, int depth, string? mergeLevel, bool fullBookUpdates, Action<DataEvent<Objects.Models.V2.CoinExOrderBook>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to order book updates
@@ -92,7 +92,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, int depth, string? mergeLevel, bool fullBookUpdates, Action<DataEvent<Objects.Models.V2.CoinExOrderBook>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, int depth, string? mergeLevel, bool fullBookUpdates, Action<DataEvent<Objects.Models.V2.CoinExOrderBook>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to live trade updates
@@ -107,7 +107,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to live trade updates
@@ -122,7 +122,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to live trade updates
@@ -136,7 +136,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(Action<DataEvent<CoinExTrade[]>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to index price updates
@@ -151,7 +151,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToIndexPriceUpdatesAsync(string symbol, Action<DataEvent<CoinExIndexPriceUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToIndexPriceUpdatesAsync(string symbol, Action<DataEvent<CoinExIndexPriceUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to index price updates
@@ -166,7 +166,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToIndexPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExIndexPriceUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToIndexPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExIndexPriceUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to book price updates
@@ -181,7 +181,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(string symbol, Action<DataEvent<CoinExBookPriceUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(string symbol, Action<DataEvent<CoinExBookPriceUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to book price updates
@@ -196,7 +196,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExBookPriceUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<CoinExBookPriceUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user order updates
@@ -210,7 +210,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(Action<DataEvent<CoinExOrderUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(Action<DataEvent<CoinExOrderUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user stop order updates
@@ -224,7 +224,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToStopOrderUpdatesAsync(Action<DataEvent<CoinExStopOrderUpdate>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToStopOrderUpdatesAsync(Action<DataEvent<CoinExStopOrderUpdate>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user trade updates
@@ -238,7 +238,7 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(Action<DataEvent<CoinExUserTrade>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(Action<DataEvent<CoinExUserTrade>> onMessage, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to user balance updates
@@ -252,6 +252,6 @@ namespace CoinEx.Net.Interfaces.Clients.SpotApiV2
         /// <param name="onMessage">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(Action<DataEvent<CoinExBalanceUpdate[]>> onMessage, CancellationToken ct = default);
+        Task<WebSocketResult<UpdateSubscription>> SubscribeToBalanceUpdatesAsync(Action<DataEvent<CoinExBalanceUpdate[]>> onMessage, CancellationToken ct = default);
     }
 }

--- a/CoinEx.Net/Objects/Sockets/V2/Queries/CoinExQuery.cs
+++ b/CoinEx.Net/Objects/Sockets/V2/Queries/CoinExQuery.cs
@@ -24,15 +24,15 @@ namespace CoinEx.Net.Objects.Sockets.V2.Queries
             _client = client;
             var id = ((CoinExSocketRequest)Request).Id.ToString();
 
-            MessageRouter = MessageRouter.CreateWithoutTopicFilter<CoinExSocketResponse>(id, HandleMessage);
+            MessageRouter = MessageRouter.CreateForQuery<CoinExSocketResponse>(id, HandleMessage);
         }
 
         public CallResult<CoinExSocketResponse> HandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, CoinExSocketResponse message)
         {
             if (message.Code != 0)
-                return new CallResult<CoinExSocketResponse>(new ServerError(message.Code, _client.GetErrorInfo(message.Code, message.Message)));
+                return CallResult<CoinExSocketResponse>.Fail(new ServerError(message.Code, _client.GetErrorInfo(message.Code, message.Message)), originalData);
 
-            return new CallResult<CoinExSocketResponse>(message, originalData, null);
+            return CallResult<CoinExSocketResponse>.Ok(message, originalData);
         }
     }
 }

--- a/CoinEx.Net/Objects/Sockets/V2/Subscriptions/CoinExFuturesOrderBookSubscription.cs
+++ b/CoinEx.Net/Objects/Sockets/V2/Subscriptions/CoinExFuturesOrderBookSubscription.cs
@@ -30,7 +30,7 @@ namespace CoinEx.Net.Objects.Sockets.V2.Subscriptions
 
             IndividualSubscriptionCount = Math.Min(1, symbols.Length);
 
-            MessageRouter = MessageRouter.CreateWithTopicFilters<CoinExSocketUpdate<CoinExOrderBook>>("depth.update", symbols, DoHandleMessage);
+            MessageRouter = MessageRouter.CreateForEvent<CoinExSocketUpdate<CoinExOrderBook>>("depth.update", symbols, DoHandleMessage);
         }
 
         public CallResult DoHandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, CoinExSocketUpdate<CoinExOrderBook> message)
@@ -43,7 +43,7 @@ namespace CoinEx.Net.Objects.Sockets.V2.Subscriptions
                 .WithSymbol(message.Data.Symbol)
                 .WithDataTimestamp(message.Data.Data.UpdateTime, _client.GetTimeOffset())
                 .WithUpdateType(message.Data.IsFull ? SocketUpdateType.Snapshot : SocketUpdateType.Update));
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
 
         protected override Query? GetSubQuery(SocketConnection connection)

--- a/CoinEx.Net/Objects/Sockets/V2/Subscriptions/CoinExFuturesTickerSubscription.cs
+++ b/CoinEx.Net/Objects/Sockets/V2/Subscriptions/CoinExFuturesTickerSubscription.cs
@@ -30,19 +30,19 @@ namespace CoinEx.Net.Objects.Sockets.V2.Subscriptions
 
             IndividualSubscriptionCount = Math.Max(1, symbols.Length);
 
-            MessageRouter = MessageRouter.CreateWithoutTopicFilter<CoinExSocketUpdate<CoinExFuturesTickerUpdateWrapper>>("state.update", DoHandleMessage);
+            MessageRouter = MessageRouter.CreateForEvent<CoinExSocketUpdate<CoinExFuturesTickerUpdateWrapper>>("state.update", DoHandleMessage);
         }
 
         public CallResult DoHandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, CoinExSocketUpdate<CoinExFuturesTickerUpdateWrapper> message)
         {
             var relevant = message.Data.Tickers.Where(d => _symbols == null || _symbols.Contains(d.Symbol)).ToArray();
             if (!relevant.Any())
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
 
             _handler.Invoke(new DataEvent<CoinExFuturesTickerUpdate[]>(CoinExExchange.ExchangeName, relevant, receiveTime, originalData)
                 .WithStreamId(message.Method)
                 .WithUpdateType(SocketUpdateType.Update));
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
 
         protected override Query? GetSubQuery(SocketConnection connection)

--- a/CoinEx.Net/Objects/Sockets/V2/Subscriptions/CoinExOrderBookSubscription.cs
+++ b/CoinEx.Net/Objects/Sockets/V2/Subscriptions/CoinExOrderBookSubscription.cs
@@ -30,7 +30,7 @@ namespace CoinEx.Net.Objects.Sockets.V2.Subscriptions
 
             IndividualSubscriptionCount = Math.Min(1, symbols.Length);
 
-            MessageRouter = MessageRouter.CreateWithTopicFilters<CoinExSocketUpdate<CoinExOrderBook>>("depth.update", symbols, DoHandleMessage);
+            MessageRouter = MessageRouter.CreateForEvent<CoinExSocketUpdate<CoinExOrderBook>>("depth.update", symbols, DoHandleMessage);
         }
 
         public CallResult DoHandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, CoinExSocketUpdate<CoinExOrderBook> message)
@@ -43,7 +43,7 @@ namespace CoinEx.Net.Objects.Sockets.V2.Subscriptions
                 .WithSymbol(message.Data.Symbol)
                 .WithDataTimestamp(message.Data.Data.UpdateTime, _client.GetTimeOffset())
                 .WithUpdateType(message.Data.IsFull ? SocketUpdateType.Snapshot : SocketUpdateType.Update));
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
 
         protected override Query? GetSubQuery(SocketConnection connection)

--- a/CoinEx.Net/Objects/Sockets/V2/Subscriptions/CoinExSubscription.cs
+++ b/CoinEx.Net/Objects/Sockets/V2/Subscriptions/CoinExSubscription.cs
@@ -31,13 +31,16 @@ namespace CoinEx.Net.Objects.Sockets.V2.Subscriptions
 
             IndividualSubscriptionCount = Math.Max(1, symbols?.Length ?? 1);
 
-            MessageRouter = MessageRouter.CreateWithOptionalTopicFilters<CoinExSocketUpdate<T>>(_topic + ".update", symbols, DoHandleMessage);
+            if (symbols == null || symbols.Length == 0)
+                MessageRouter = MessageRouter.CreateForEvent<CoinExSocketUpdate<T>>(_topic + ".update", DoHandleMessage);
+            else
+                MessageRouter = MessageRouter.CreateForEvent<CoinExSocketUpdate<T>>(_topic + ".update", symbols, DoHandleMessage);
         }
 
         public CallResult DoHandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, CoinExSocketUpdate<T> message)
         {
             _handler.Invoke(receiveTime, originalData, ConnectionInvocations, message);
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
 
 

--- a/CoinEx.Net/Objects/Sockets/V2/Subscriptions/CoinExTickerSubscription.cs
+++ b/CoinEx.Net/Objects/Sockets/V2/Subscriptions/CoinExTickerSubscription.cs
@@ -30,19 +30,19 @@ namespace CoinEx.Net.Objects.Sockets.V2.Subscriptions
 
             IndividualSubscriptionCount = Math.Max(1, symbols.Length);
 
-            MessageRouter = MessageRouter.CreateWithoutTopicFilter<CoinExSocketUpdate<CoinExTickerUpdateWrapper>>("state.update", DoHandleMessage);
+            MessageRouter = MessageRouter.CreateForEvent<CoinExSocketUpdate<CoinExTickerUpdateWrapper>>("state.update", DoHandleMessage);
         }
 
         public CallResult DoHandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, CoinExSocketUpdate<CoinExTickerUpdateWrapper> message)
         {
             var relevant = message.Data.Tickers.Where(d => _symbols == null || _symbols.Contains(d.Symbol)).ToArray();
             if (!relevant.Any())
-                return CallResult.SuccessResult;
+                return CallResult.Ok();
 
             _handler.Invoke(new DataEvent<CoinExTicker[]>(CoinExExchange.ExchangeName, relevant, receiveTime, originalData)
                 .WithStreamId(message.Method)
                 .WithUpdateType(SocketUpdateType.Update));
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
 
         protected override Query? GetSubQuery(SocketConnection connection)

--- a/CoinEx.Net/Objects/Sockets/V2/Subscriptions/CoinExTradesSubscription.cs
+++ b/CoinEx.Net/Objects/Sockets/V2/Subscriptions/CoinExTradesSubscription.cs
@@ -30,7 +30,7 @@ namespace CoinEx.Net.Objects.Sockets.V2.Subscriptions
 
             IndividualSubscriptionCount = Math.Max(1, symbols.Length);
 
-            MessageRouter = MessageRouter.CreateWithOptionalTopicFilters<CoinExSocketUpdate<CoinExTradeWrapper>>("deals.update", symbols, DoHandleRouteMessage);
+            MessageRouter = MessageRouter.CreateForEvent<CoinExSocketUpdate<CoinExTradeWrapper>>("deals.update", symbols, DoHandleRouteMessage);
         }
 
         public CallResult DoHandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, CoinExSocketUpdate<CoinExTradeWrapper> message)
@@ -38,7 +38,7 @@ namespace CoinEx.Net.Objects.Sockets.V2.Subscriptions
             if (_symbols?.Any() == true)
             {
                 if (!_symbols.Contains(message.Data.Symbol))
-                    return CallResult.SuccessResult;
+                    return CallResult.Ok();
             }
 
             var timestamp = message.Data.Trades.Max(x => x.Timestamp);
@@ -49,7 +49,7 @@ namespace CoinEx.Net.Objects.Sockets.V2.Subscriptions
                 .WithSymbol(message.Data.Symbol)
                 .WithDataTimestamp(timestamp, _client.GetTimeOffset())
                 .WithUpdateType(ConnectionInvocations == 1 ? SocketUpdateType.Snapshot : SocketUpdateType.Update));
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
 
         public CallResult DoHandleRouteMessage(SocketConnection connection, DateTime receiveTime, string? originalData, CoinExSocketUpdate<CoinExTradeWrapper> message)
@@ -63,7 +63,7 @@ namespace CoinEx.Net.Objects.Sockets.V2.Subscriptions
                 .WithSymbol(message.Data.Symbol)
                 .WithDataTimestamp(timestamp, _client.GetTimeOffset())
                 .WithUpdateType(ConnectionInvocations == 1 ? SocketUpdateType.Snapshot : SocketUpdateType.Update));
-            return CallResult.SuccessResult;
+            return CallResult.Ok();
         }
 
         protected override Query? GetSubQuery(SocketConnection connection)

--- a/CoinEx.Net/SymbolOrderBooks/CoinExFuturesSymbolOrderBook.cs
+++ b/CoinEx.Net/SymbolOrderBooks/CoinExFuturesSymbolOrderBook.cs
@@ -62,26 +62,26 @@ namespace CoinEx.Net.SymbolOrderBooks
         protected override async Task<CallResult<UpdateSubscription>> DoStartAsync(CancellationToken ct)
         {
             var result = await _socketClient.FuturesApi.SubscribeToOrderBookUpdatesAsync(Symbol, Levels!.Value, null, true, HandleUpdate).ConfigureAwait(false);
-            if (!result)
-                return result;
+            if (!result.Success)
+                return CallResult.Fail<UpdateSubscription>(result.Error);
 
             if (ct.IsCancellationRequested)
             {
                 await result.Data.CloseAsync().ConfigureAwait(false);
-                return result.AsError<UpdateSubscription>(new CancellationRequestedError());
+                return CallResult.Fail<UpdateSubscription>(new CancellationRequestedError());
             }
 
             Status = OrderBookStatus.Syncing;
 
             var setResult = await WaitForSetOrderBookAsync(_initialDataTimeout, ct).ConfigureAwait(false);
-            if (!setResult)
+            if (!setResult.Success)
                 await result.Data.CloseAsync().ConfigureAwait(false);
 
-            return setResult ? result : new CallResult<UpdateSubscription>(setResult.Error!);
+            return setResult.Success ? CallResult.Ok(result.Data) : CallResult.Fail<UpdateSubscription>(setResult.Error!);
         }
 
         /// <inheritdoc />
-        protected override async Task<CallResult<bool>> DoResyncAsync(CancellationToken ct)
+        protected override async Task<CallResult> DoResyncAsync(CancellationToken ct)
         {
             return await WaitForSetOrderBookAsync(_initialDataTimeout, ct).ConfigureAwait(false);
         }

--- a/CoinEx.Net/SymbolOrderBooks/CoinExSpotSymbolOrderBook.cs
+++ b/CoinEx.Net/SymbolOrderBooks/CoinExSpotSymbolOrderBook.cs
@@ -62,26 +62,26 @@ namespace CoinEx.Net.SymbolOrderBooks
         protected override async Task<CallResult<UpdateSubscription>> DoStartAsync(CancellationToken ct)
         {
             var result = await _socketClient.SpotApiV2.SubscribeToOrderBookUpdatesAsync(Symbol, Levels!.Value, null, false, HandleUpdate).ConfigureAwait(false);
-            if (!result)
-                return result;
+            if (!result.Success)
+                return CallResult.Fail<UpdateSubscription>(result.Error);
 
             if (ct.IsCancellationRequested)
             {
                 await result.Data.CloseAsync().ConfigureAwait(false);
-                return result.AsError<UpdateSubscription>(new CancellationRequestedError());
+                return CallResult.Fail<UpdateSubscription>(new CancellationRequestedError());
             }
 
             Status = OrderBookStatus.Syncing;
 
             var setResult = await WaitForSetOrderBookAsync(_initialDataTimeout, ct).ConfigureAwait(false);
-            if (!setResult)
+            if (!setResult.Success)
                 await result.Data.CloseAsync().ConfigureAwait(false);
 
-            return setResult ? result : new CallResult<UpdateSubscription>(setResult.Error!);
+            return setResult.Success ? CallResult.Ok(result.Data) : CallResult.Fail<UpdateSubscription>(setResult.Error!);
         }
 
         /// <inheritdoc />
-        protected override async Task<CallResult<bool>> DoResyncAsync(CancellationToken ct)
+        protected override async Task<CallResult> DoResyncAsync(CancellationToken ct)
         {
             return await WaitForSetOrderBookAsync(_initialDataTimeout, ct).ConfigureAwait(false);
         }

--- a/Examples/ai-friendly/04-multi-exchange.cs
+++ b/Examples/ai-friendly/04-multi-exchange.cs
@@ -1,6 +1,7 @@
 // 04-multi-exchange.cs
 //
-// Demonstrates: writing exchange-agnostic code using CryptoExchange.Net.SharedApis.
+// Demonstrates: writing exchange-agnostic code using CryptoExchange.Net.SharedApis
+// with capability discovery and shared REST/WebSocket calls.
 // Same code works against CoinEx, Binance, OKX, Bybit, Kraken, and other
 // exchanges from the CryptoExchange.Net family.
 //
@@ -18,6 +19,8 @@ using CryptoExchange.Net.SharedApis;
 // IBalanceRestClient, etc. - a common abstraction across exchanges.
 
 ISpotTickerRestClient coinexShared = new CoinExRestClient().SpotApiV2.SharedClient;
+var info = coinexShared.Discover();
+Console.WriteLine(info);
 
 // To add Binance or OKX, install the package and:
 //   ISpotTickerRestClient binanceShared = new BinanceRestClient().SpotApi.SharedClient;

--- a/Examples/ai-friendly/05-error-handling.cs
+++ b/Examples/ai-friendly/05-error-handling.cs
@@ -1,6 +1,7 @@
 // 05-error-handling.cs
 //
-// Demonstrates: HttpResult patterns, retry logic, common error scenarios.
+// Demonstrates: HttpResult, WebSocketResult, ExchangeCallResult, retry logic,
+// and common error scenarios.
 //
 // Setup: dotnet add package CoinEx.Net
 
@@ -15,7 +16,9 @@ var client = new CoinExRestClient(options =>
 });
 
 // ---- 1. THE BASIC PATTERN ----
-// Every method returns HttpResult<T> (REST) or WebSocketResult<T> (WebSocket).
+// REST methods return HttpResult<T> or HttpResult.
+// WebSocket subscriptions return WebSocketResult<UpdateSubscription>.
+// Shared non-I/O symbol/cache helpers return ExchangeCallResult<T>.
 // .Success is true/false. .Data is the payload, only valid when .Success is true.
 // .Error contains structured error info when .Success is false.
 // .Error.IsTransient hints if a retry might succeed.

--- a/Examples/ai-friendly/05-error-handling.cs
+++ b/Examples/ai-friendly/05-error-handling.cs
@@ -1,6 +1,6 @@
 // 05-error-handling.cs
 //
-// Demonstrates: WebCallResult patterns, retry logic, common error scenarios.
+// Demonstrates: HttpResult patterns, retry logic, common error scenarios.
 //
 // Setup: dotnet add package CoinEx.Net
 
@@ -15,7 +15,7 @@ var client = new CoinExRestClient(options =>
 });
 
 // ---- 1. THE BASIC PATTERN ----
-// Every method returns WebCallResult<T> (REST) or CallResult<T> (WebSocket).
+// Every method returns HttpResult<T> (REST) or WebSocketResult<T> (WebSocket).
 // .Success is true/false. .Data is the payload, only valid when .Success is true.
 // .Error contains structured error info when .Success is false.
 // .Error.IsTransient hints if a retry might succeed.
@@ -38,11 +38,11 @@ else
 // Retry only on transient errors such as network issues, rate limits, or server overload.
 // Do not retry validation errors, bad credentials, or insufficient balance.
 
-async Task<WebCallResult<T>> WithRetry<T>(
-    Func<Task<WebCallResult<T>>> call,
+async Task<HttpResult<T>> WithRetry<T>(
+    Func<Task<HttpResult<T>>> call,
     int maxAttempts = 3)
 {
-    WebCallResult<T> last = default!;
+    HttpResult<T> last = default!;
     for (var attempt = 1; attempt <= maxAttempts; attempt++)
     {
         last = await call();

--- a/Examples/ai-friendly/README.md
+++ b/Examples/ai-friendly/README.md
@@ -14,8 +14,8 @@ These examples are optimized for AI coding assistants and quick onboarding. Each
 | `01-spot-quickstart.cs` | Client setup, public ticker, authenticated balance, place limit order, query order status |
 | `02-futures.cs` | Futures leverage, market order, get position, close position |
 | `03-websocket.cs` | Subscribe to ticker, order book, trades, user streams with proper teardown |
-| `04-multi-exchange.cs` | `CryptoExchange.Net.SharedApis` pattern for exchange-agnostic code |
-| `05-error-handling.cs` | `HttpResult` patterns, retry, common error scenarios |
+| `04-multi-exchange.cs` | `CryptoExchange.Net.SharedApis` pattern, capability discovery, and shared subscriptions |
+| `05-error-handling.cs` | `HttpResult`, `WebSocketResult`, and `ExchangeCallResult` patterns, retry, common error scenarios |
 
 ## Running
 

--- a/Examples/ai-friendly/README.md
+++ b/Examples/ai-friendly/README.md
@@ -15,7 +15,7 @@ These examples are optimized for AI coding assistants and quick onboarding. Each
 | `02-futures.cs` | Futures leverage, market order, get position, close position |
 | `03-websocket.cs` | Subscribe to ticker, order book, trades, user streams with proper teardown |
 | `04-multi-exchange.cs` | `CryptoExchange.Net.SharedApis` pattern for exchange-agnostic code |
-| `05-error-handling.cs` | `WebCallResult` patterns, retry, common error scenarios |
+| `05-error-handling.cs` | `HttpResult` patterns, retry, common error scenarios |
 
 ## Running
 

--- a/docs/ai-api-map.md
+++ b/docs/ai-api-map.md
@@ -161,6 +161,7 @@ Use this file to route common user intents to the correct CoinEx.Net client memb
 | Shared futures REST client | `new CoinExRestClient().FuturesApi.SharedClient` |
 | Shared spot socket client | `new CoinExSocketClient().SpotApiV2.SharedClient` |
 | Shared futures socket client | `new CoinExSocketClient().FuturesApi.SharedClient` |
+| Discover shared capabilities | `client.SpotApiV2.SharedClient.Discover()` / `client.FuturesApi.SharedClient.Discover()` |
 | Shared spot ticker REST | `ISpotTickerRestClient.GetSpotTickerAsync(new GetTickerRequest(symbol))` |
 | Shared futures ticker REST | `IFuturesTickerRestClient.GetFuturesTickerAsync(new GetTickerRequest(symbol))` |
 | Shared spot order REST | `ISpotOrderRestClient.PlaceSpotOrderAsync(...)` |
@@ -170,6 +171,8 @@ Use this file to route common user intents to the correct CoinEx.Net client memb
 | Shared ticker socket | `ITickerSocketClient.SubscribeToTickerUpdatesAsync(...)` |
 | Shared order book socket | `IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(...)` |
 
+Shared REST calls return `HttpResult<T>` / `HttpResult`. Shared socket subscriptions return `WebSocketResult<UpdateSubscription>`. Shared non-I/O symbol/cache helpers such as symbol support checks return `ExchangeCallResult<T>`.
+
 For shared socket subscriptions, keep the concrete socket client and unsubscribe with `await socketClient.UnsubscribeAsync(subscription.Data)`.
 
 ## Result Handling
@@ -177,8 +180,9 @@ For shared socket subscriptions, keep the concrete socket client and unsubscribe
 | Situation | Pattern |
 |---|---|
 | REST success check | `if (!result.Success) { Console.WriteLine(result.Error); return; }` |
-| Socket subscription success check | `if (!sub.Success) { Console.WriteLine(sub.Error); return; }` |
+| Socket subscription success check | `WebSocketResult<UpdateSubscription> sub = await ...; if (!sub.Success) { Console.WriteLine(sub.Error); return; }` |
 | Read REST data | Read `result.Data` only after `result.Success` |
+| Shared helper data | Read `ExchangeCallResult<T>.Data` only after `result.Success` |
 | Retry decision | Retry only when `result.Error?.IsTransient == true` |
 | Cancellation | Pass `ct: cancellationToken` |
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -25,6 +25,7 @@ Primary documentation:
 - Always check `.Success` before reading `.Data`.
 - REST methods return `HttpResult<T>` or `HttpResult`.
 - WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`.
+- Shared non-I/O symbol/cache helpers return `ExchangeCallResult<T>`.
 - Reuse clients. Do not instantiate REST or socket clients per request in production code.
 - Prefer dependency injection for long-running services.
 - Store WebSocket subscriptions and unsubscribe during shutdown.
@@ -34,7 +35,7 @@ Primary documentation:
 - For futures examples, use `FuturesApi`; CoinEx.Net does not split futures into Binance-style USD-M and COIN-M branches.
 - For spot trading methods, pass `AccountType.Spot` or `AccountType.Margin`.
 - Use `OrderTypeV2` for spot and futures order type values.
-- For multi-exchange code, use `CryptoExchange.Net.SharedApis` interfaces from each API surface's `.SharedClient`.
+- For multi-exchange code, use `CryptoExchange.Net.SharedApis` interfaces from each API surface's `.SharedClient` and call `.Discover()` to inspect supported shared features.
 
 ## Installation
 
@@ -422,6 +423,10 @@ using CoinEx.Net.Clients;
 using CryptoExchange.Net.SharedApis;
 
 ISpotTickerRestClient tickerClient = new CoinExRestClient().SpotApiV2.SharedClient;
+var info = tickerClient.Discover();
+var supported = info.Features.Where(x => x.Supported).Select(x => x.EndpointName);
+Console.WriteLine($"{info.Exchange} {info.TypeName}: {string.Join(", ", supported)}");
+
 var symbol = new SharedSymbol(TradingMode.Spot, "BTC", "USDT");
 
 var ticker = await tickerClient.GetSpotTickerAsync(new GetTickerRequest(symbol));
@@ -506,10 +511,10 @@ Examples/ai-friendly/03-websocket.cs
   Public ticker stream, order book stream, trade stream, authenticated user streams, success checks, teardown.
 
 Examples/ai-friendly/04-multi-exchange.cs
-  CryptoExchange.Net.SharedApis REST and socket patterns.
+  CryptoExchange.Net.SharedApis REST/socket patterns plus capability discovery.
 
 Examples/ai-friendly/05-error-handling.cs
-  HttpResult pattern, transient retry, CoinEx error categories, symbol precision handling.
+  HttpResult, WebSocketResult, ExchangeCallResult, transient retry, CoinEx error categories, symbol precision handling.
 ```
 
 These files are intended to be copied into a console `Program.cs` after `dotnet add package CoinEx.Net`.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -23,8 +23,8 @@ Primary documentation:
 - Use `CoinExCredentials`, not generic `ApiCredentials`, for API key setup.
 - Include `using CoinEx.Net;` when using `CoinExCredentials` or `CoinExEnvironment`.
 - Always check `.Success` before reading `.Data`.
-- REST methods return `WebCallResult<T>` or `WebCallResult`.
-- WebSocket subscriptions return `CallResult<UpdateSubscription>`.
+- REST methods return `HttpResult<T>` or `HttpResult`.
+- WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`.
 - Reuse clients. Do not instantiate REST or socket clients per request in production code.
 - Prefer dependency injection for long-running services.
 - Store WebSocket subscriptions and unsubscribe during shutdown.
@@ -168,9 +168,9 @@ var price = result.Data.First().LastPrice;
 For retry logic, only retry transient errors:
 
 ```csharp
-async Task<WebCallResult<T>> WithRetry<T>(Func<Task<WebCallResult<T>>> call, int maxAttempts = 3)
+async Task<HttpResult<T>> WithRetry<T>(Func<Task<HttpResult<T>>> call, int maxAttempts = 3)
 {
-    WebCallResult<T> last = default!;
+    HttpResult<T> last = default!;
 
     for (var attempt = 1; attempt <= maxAttempts; attempt++)
     {
@@ -509,7 +509,7 @@ Examples/ai-friendly/04-multi-exchange.cs
   CryptoExchange.Net.SharedApis REST and socket patterns.
 
 Examples/ai-friendly/05-error-handling.cs
-  WebCallResult pattern, transient retry, CoinEx error categories, symbol precision handling.
+  HttpResult pattern, transient retry, CoinEx error categories, symbol precision handling.
 ```
 
 These files are intended to be copied into a console `Program.cs` after `dotnet add package CoinEx.Net`.

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Strongly typed .NET client library for the CoinEx REST and WebSocket APIs. Supports CoinEx Spot V2, margin account operations, Futures, account/asset operations, typed market data, order placement, WebSocket subscriptions, local order books, and shared multi-exchange abstractions through CryptoExchange.Net.
 
-CoinEx.Net is the C# client for CoinEx in the CryptoExchange.Net ecosystem. It provides typed REST and WebSocket clients, automatic WebSocket reconnection, client-side rate limiting, structured error handling via `HttpResult<T>` / `WebSocketResult<T>`, native AOT support, and shared API interfaces for exchange-agnostic applications. Current version: 10.10.0. Targets netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
+CoinEx.Net is the C# client for CoinEx in the CryptoExchange.Net ecosystem. REST methods return `HttpResult<T>` / `HttpResult`, WebSocket subscriptions return `WebSocketResult<UpdateSubscription>`, and shared symbol/cache helpers return `ExchangeCallResult<T>`. It also provides typed REST and WebSocket clients, automatic WebSocket reconnection, client-side rate limiting, native AOT support, and shared API interfaces for exchange-agnostic applications. Current version: 10.10.0. Targets netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
 
 ## Documentation
 
@@ -18,8 +18,8 @@ CoinEx.Net is the C# client for CoinEx in the CryptoExchange.Net ecosystem. It p
 - [Spot Quickstart](https://github.com/JKorf/CoinEx.Net/blob/master/Examples/ai-friendly/01-spot-quickstart.cs): Client setup, ticker, account balance, limit order placement, order status check
 - [Futures Trading](https://github.com/JKorf/CoinEx.Net/blob/master/Examples/ai-friendly/02-futures.cs): Futures leverage, market order, position retrieval, position close
 - [WebSocket Streams](https://github.com/JKorf/CoinEx.Net/blob/master/Examples/ai-friendly/03-websocket.cs): Ticker subscription, order book/trade subscriptions, authenticated user streams with proper teardown
-- [Multi-Exchange Pattern](https://github.com/JKorf/CoinEx.Net/blob/master/Examples/ai-friendly/04-multi-exchange.cs): Using CryptoExchange.Net SharedApis for exchange-agnostic code
-- [Error Handling](https://github.com/JKorf/CoinEx.Net/blob/master/Examples/ai-friendly/05-error-handling.cs): HttpResult pattern, retry logic, common errors and their handling
+- [Multi-Exchange Pattern](https://github.com/JKorf/CoinEx.Net/blob/master/Examples/ai-friendly/04-multi-exchange.cs): CryptoExchange.Net SharedApis, capability discovery, and shared subscriptions
+- [Error Handling](https://github.com/JKorf/CoinEx.Net/blob/master/Examples/ai-friendly/05-error-handling.cs): HttpResult, WebSocketResult, and ExchangeCallResult patterns
 - [Full Examples Repository](https://github.com/JKorf/CoinEx.Net/tree/master/Examples): Console, API, order book, and tracker examples
 
 ## Critical Usage Rules

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Strongly typed .NET client library for the CoinEx REST and WebSocket APIs. Supports CoinEx Spot V2, margin account operations, Futures, account/asset operations, typed market data, order placement, WebSocket subscriptions, local order books, and shared multi-exchange abstractions through CryptoExchange.Net.
 
-CoinEx.Net is the C# client for CoinEx in the CryptoExchange.Net ecosystem. It provides typed REST and WebSocket clients, automatic WebSocket reconnection, client-side rate limiting, structured error handling via `WebCallResult<T>` / `CallResult<T>`, native AOT support, and shared API interfaces for exchange-agnostic applications. Current version: 10.10.0. Targets netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
+CoinEx.Net is the C# client for CoinEx in the CryptoExchange.Net ecosystem. It provides typed REST and WebSocket clients, automatic WebSocket reconnection, client-side rate limiting, structured error handling via `HttpResult<T>` / `WebSocketResult<T>`, native AOT support, and shared API interfaces for exchange-agnostic applications. Current version: 10.10.0. Targets netstandard2.0, netstandard2.1, net8.0, net9.0, net10.0.
 
 ## Documentation
 
@@ -19,7 +19,7 @@ CoinEx.Net is the C# client for CoinEx in the CryptoExchange.Net ecosystem. It p
 - [Futures Trading](https://github.com/JKorf/CoinEx.Net/blob/master/Examples/ai-friendly/02-futures.cs): Futures leverage, market order, position retrieval, position close
 - [WebSocket Streams](https://github.com/JKorf/CoinEx.Net/blob/master/Examples/ai-friendly/03-websocket.cs): Ticker subscription, order book/trade subscriptions, authenticated user streams with proper teardown
 - [Multi-Exchange Pattern](https://github.com/JKorf/CoinEx.Net/blob/master/Examples/ai-friendly/04-multi-exchange.cs): Using CryptoExchange.Net SharedApis for exchange-agnostic code
-- [Error Handling](https://github.com/JKorf/CoinEx.Net/blob/master/Examples/ai-friendly/05-error-handling.cs): WebCallResult pattern, retry logic, common errors and their handling
+- [Error Handling](https://github.com/JKorf/CoinEx.Net/blob/master/Examples/ai-friendly/05-error-handling.cs): HttpResult pattern, retry logic, common errors and their handling
 - [Full Examples Repository](https://github.com/JKorf/CoinEx.Net/tree/master/Examples): Console, API, order book, and tracker examples
 
 ## Critical Usage Rules


### PR DESCRIPTION
* Result types:
  * (Web)CallResult types are replaced by HttpResult, WebSocketResult and QueryResult with the same logic
  * WebSocketResult and QueryResult now return additional info for websocket operations
  * Updated result types to record type
  * Removed implicit result type conversion to bool, `if (result)` no longer works, instead use `if (result.Success)`
  * Fixed result object nullability hinting, for example Data might be null if Success isn't checked for true

* Clients:
  * Added ToString overrides on base API types
  * Added Exchange property on BaseApiClient
  * Added ApiCredentials property on Api clients
  * Updated ILogger source from client name to topic specific client name
  * Removed logging from client creation
  * Fixed issue in SocketApiClient.GetSocketConnection causing requests to always wait the full max 10 seconds when there was a reconnecting socket

* Shared APIs:
  * Added missing dedicated option types
  * Added Discover method on ISharedClient interface, returning info on supported capabilities and operations
  * Added ResetStaticExchangeParameters method on ExchangeParameters
  * Added Status property to SharedWithdrawal model
  * Added TradingModes property to SharedBalance model
  * Updated Shared ExchangeParameters parameter names to be case insensitive
  * Updated code comments
  * Replaced ExchangeResult with ExchangeCallResult type
  * Removed TradingMode from the response model, only maintained on models where it makes sense

* Added async streaming on UserDataTracker items with StreamUpdatesAsync
* Added cancellation token support to UserDataTracker starting
* Added SupportedEnvironments property to PlatformInfo
* Added Clear() method on UserClientProvider to clear all cached clients
* Added setter to CoinExExchange.RateLimiter to allow custom rate limit settings
* Various small performance improvements
* Fixed websocket connection attempts counting towards rate limit even when server could not be reached