### PR TITLE
Shared asset types

### DIFF
--- a/CoinEx.Net/Clients/CoinExRestClient.cs
+++ b/CoinEx.Net/Clients/CoinExRestClient.cs
@@ -43,7 +43,7 @@ namespace CoinEx.Net.Clients
         {
             Initialize(options.Value);
 
-            FuturesApi = AddApiClient(new CoinExRestClientFuturesApi(loggerFactory, httpClient, options.Value));
+            FuturesApi = AddApiClient(new CoinExRestClientFuturesApi(this, loggerFactory, httpClient, options.Value));
             SpotApiV2 = AddApiClient(new SpotApiV2.CoinExRestClientSpotApi(loggerFactory, httpClient, options.Value));
         }
         #endregion

--- a/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApi.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApi.cs
@@ -32,6 +32,8 @@ namespace CoinEx.Net.Clients.FuturesApi
 
         protected override IRestMessageHandler MessageHandler { get; } = new CoinExRestMessageHandler(CoinExErrors.RestErrorMapping);
         protected override ErrorMapping ErrorMapping => CoinExErrors.RestErrorMapping;
+
+        internal CoinExRestClient _baseClient;
         #endregion
 
         #region Api clients
@@ -44,9 +46,11 @@ namespace CoinEx.Net.Clients.FuturesApi
         #endregion
 
         #region ctor
-        internal CoinExRestClientFuturesApi(ILoggerFactory? loggerFactory, HttpClient? httpClient, CoinExRestOptions options) :
+        internal CoinExRestClientFuturesApi(CoinExRestClient baseClient, ILoggerFactory? loggerFactory, HttpClient? httpClient, CoinExRestOptions options) :
             base(loggerFactory, CoinExExchange.Metadata.Id, httpClient, options.Environment.RestBaseAddress, options, options.FuturesOptions)
         {
+            _baseClient = baseClient;
+
             Account = new CoinExRestClientFuturesApiAccount(this);
             ExchangeData = new CoinExRestClientFuturesApiExchangeData(this);
             Trading = new CoinExRestClientFuturesApiTrading(this);

--- a/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiShared.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiShared.cs
@@ -135,6 +135,7 @@ namespace CoinEx.Net.Clients.FuturesApi
 
         #region Futures Symbol client
 
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
@@ -142,30 +143,65 @@ namespace CoinEx.Net.Clients.FuturesApi
             if (validationError != null)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(Exchange, validationError);
 
-            var result = await ExchangeData.GetSymbolsAsync(ct: ct).ConfigureAwait(false);
-            if (!result.Success)
-                return HttpResult.Fail<SharedFuturesSymbol[]>(result);
+            var symbolsTask = ExchangeData.GetSymbolsAsync(ct: ct);
+            var assetsTask = _baseClient.SpotApiV2.ExchangeData.GetAssetsAsync(ct: ct);
+            await Task.WhenAll(symbolsTask, assetsTask).ConfigureAwait(false);
+            var symbolsResult = symbolsTask.Result;
+            var assetsResult = assetsTask.Result;
+            if (!symbolsResult.Success)
+                return HttpResult.Fail<SharedFuturesSymbol[]>(symbolsResult);
+            if (!assetsResult.Success)
+                return HttpResult.Fail<SharedFuturesSymbol[]>(assetsResult);
 
-            IEnumerable<CoinExFuturesSymbol> data = result.Data;
-            if (request.TradingMode.HasValue)
-            {
-                data = data.Where(x =>
-                    request.TradingMode == TradingMode.PerpetualLinear ? x.ContractType == ContractType.Linear : x.ContractType == ContractType.Inverse);
-            }
+            var data = symbolsResult.Data
+                .Select(x => ParseSymbol(x, assetsResult.Data))
+                .ToArray();
 
-            var response = HttpResult.Ok(result, data.Select(s => new SharedFuturesSymbol(
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, data);
+            return HttpResult.Ok(symbolsResult, SharedUtils.ApplySymbolFilter(data, request));
+        }
+
+        private SharedFuturesSymbol ParseSymbol(CoinExFuturesSymbol s, CoinExAsset[] assets)
+        {
+            var result = new SharedFuturesSymbol(
                 s.ContractType == ContractType.Inverse ? TradingMode.PerpetualInverse : TradingMode.PerpetualLinear,
                 s.BaseAsset, s.QuoteAsset, s.Symbol, s.TradingAvailable)
             {
                 MinTradeQuantity = s.MinOrderQuantity,
                 QuantityDecimals = s.QuantityPrecision,
                 PriceDecimals = s.PricePrecision,
-                ContractSize = 1
-            }).ToArray());
+                ContractSize = 1,
+                QuoteAssetType = SharedAssetType.Crypto,
+                QuoteAssetSubType = SharedAssetSubType.StableCoin
+            };
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, response.Data!);
-            return response;
+            if (LibraryHelpers.IsCommodity(result.BaseAsset))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Commodity;
+            }
+            else
+            {
+                var baseAsset = assets.SingleOrDefault(x => x.ShortName == s.BaseAsset);
+                if (baseAsset != null)
+                {
+                    if (baseAsset.FullName.Contains("xStock"))
+                    {
+                        result.BaseAssetType = SharedAssetType.TradFi;
+                        result.BaseAssetSubType = SharedAssetSubType.Stock;
+                    }
+                    else
+                    {
+                        result.BaseAssetType = SharedAssetType.Crypto;
+                        if (LibraryHelpers.IsStableCoin(result.BaseAsset))
+                            result.BaseAssetSubType = SharedAssetSubType.StableCoin;
+                    }
+                }
+            }
+
+            return result;
         }
+
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
         {
             if (!ExchangeSymbolCache.HasCached(_topicId, EnvironmentName, null))

--- a/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiShared.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiShared.cs
@@ -171,6 +171,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                 QuantityDecimals = s.QuantityPrecision,
                 PriceDecimals = s.PricePrecision,
                 ContractSize = 1,
+                DisplayName = s.Symbol,
                 QuoteAssetType = SharedAssetType.Crypto,
                 QuoteAssetSubType = SharedAssetSubType.StableCoin
             };

--- a/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiShared.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiShared.cs
@@ -188,7 +188,7 @@ namespace CoinEx.Net.Clients.FuturesApi
                     if (baseAsset.FullName.Contains("xStock"))
                     {
                         result.BaseAssetType = SharedAssetType.TradFi;
-                        result.BaseAssetSubType = SharedAssetSubType.Stock;
+                        result.BaseAssetSubType = SharedAssetSubType.Equity;
                     }
                     else
                     {

--- a/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiShared.cs
+++ b/CoinEx.Net/Clients/FuturesApi/CoinExRestClientFuturesApiShared.cs
@@ -135,7 +135,7 @@ namespace CoinEx.Net.Clients.FuturesApi
 
         #region Futures Symbol client
 
-        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiShared.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiShared.cs
@@ -147,7 +147,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
                     if (baseAsset.FullName.Contains("xStock"))
                     {
                         result.BaseAssetType = SharedAssetType.TradFi;
-                        result.BaseAssetSubType = SharedAssetSubType.Stock;
+                        result.BaseAssetSubType = SharedAssetSubType.Equity;
                     }
                     else
                     {

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiShared.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiShared.cs
@@ -98,6 +98,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
         #region Spot Symbol client
 
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
@@ -105,20 +106,65 @@ namespace CoinEx.Net.Clients.SpotApiV2
             if (validationError != null)
                 return HttpResult.Fail<SharedSpotSymbol[]>(Exchange, validationError);
 
-            var result = await ExchangeData.GetSymbolsAsync(ct: ct).ConfigureAwait(false);
-            if (!result.Success)
-                return HttpResult.Fail<SharedSpotSymbol[]>(result);
+            var symbolsTask = ExchangeData.GetSymbolsAsync(ct: ct);
+            var assetsTask = ExchangeData.GetAssetsAsync(ct: ct);
+            await Task.WhenAll(symbolsTask, assetsTask).ConfigureAwait(false);
+            var symbolsResult = symbolsTask.Result;
+            var assetsResult = assetsTask.Result;
+            if (!symbolsResult.Success)
+                return HttpResult.Fail<SharedSpotSymbol[]>(symbolsResult);
+            if (!assetsResult.Success)
+                return HttpResult.Fail<SharedSpotSymbol[]>(assetsResult);
 
-            var response = HttpResult.Ok(result, result.Data.Select(s => new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Name, true)
+            var data = symbolsResult.Data
+                .Select(x => ParseSymbol(x, assetsResult.Data))
+                .ToArray();
+
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, data);
+            return HttpResult.Ok(symbolsResult, SharedUtils.ApplySymbolFilter(data, request));
+        }
+
+        private SharedSpotSymbol ParseSymbol(CoinExSymbol s, CoinExAsset[] assets)
+        {
+            var result = new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Name, true)
             {
                 MinTradeQuantity = s.MinOrderQuantity,
                 PriceDecimals = s.PricePrecision,
-                QuantityDecimals = s.QuantityPrecision
-            }).ToArray());
+                QuantityDecimals = s.QuantityPrecision,
+                DisplayName = s.Name
+            };
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, response.Data!);
-            return response;
+            if (LibraryHelpers.IsCommodity(result.BaseAsset))
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Commodity;
+            }
+            else
+            {
+                var baseAsset = assets.SingleOrDefault(x => x.ShortName == s.BaseAsset);
+                if (baseAsset != null)
+                {
+                    if (baseAsset.FullName.Contains("xStock"))
+                    {
+                        result.BaseAssetType = SharedAssetType.TradFi;
+                        result.BaseAssetSubType = SharedAssetSubType.Stock;
+                    }
+                    else
+                    {
+                        result.BaseAssetType = SharedAssetType.Crypto;
+                        if (LibraryHelpers.IsStableCoin(result.BaseAsset))
+                            result.BaseAssetSubType = SharedAssetSubType.StableCoin;
+                    }
+                }
+            }
+
+            result.QuoteAssetType = SharedAssetType.Crypto;
+            if (LibraryHelpers.IsStableCoin(result.QuoteAsset))
+                result.QuoteAssetSubType = SharedAssetSubType.StableCoin;
+
+            return result;
         }
+
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
         {
             if (!ExchangeSymbolCache.HasCached(_topicId, EnvironmentName, null))

--- a/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiShared.cs
+++ b/CoinEx.Net/Clients/SpotApiV2/CoinExRestClientSpotApiShared.cs
@@ -98,7 +98,7 @@ namespace CoinEx.Net.Clients.SpotApiV2
 
         #region Spot Symbol client
 
-        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {

--- a/CoinEx.Net/CoinEx.Net.csproj
+++ b/CoinEx.Net/CoinEx.Net.csproj
@@ -55,10 +55,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Crc32.NET" Version="1.2.0" />
-    <PackageReference Include="CryptoExchange.Net" Version="12.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/CoinEx.Net/CoinEx.Net.csproj
+++ b/CoinEx.Net/CoinEx.Net.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -55,12 +55,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Crc32.NET" Version="1.2.0" />
+    <PackageReference Include="CryptoExchange.Net" Version="12.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated CryptoExchange.Net to v12.2.0 
Added SpotSymbolCatalog to Shared ISpotSymbolRestClient interface
Added FuturesSymbolCatalog to Shared IFuturesSymbolRestClient interface
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to GetSymbolsRequest model
Added DisplayName to SharedSpotSymbol and SharedFuturesSymbol models
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to SharedSpotSymbol and SharedFuturesSymbol models
Added DebuggerDisplay attributes to Shared models